### PR TITLE
bug(BLAZ-18157): Release notes added for the issue Exception is raise…

### DIFF
--- a/blazor/Release-Notes/Unreleased/Toast.md
+++ b/blazor/Release-Notes/Unreleased/Toast.md
@@ -1,0 +1,5 @@
+## Toast
+
+### Bug Fixes
+
+- `#I348947` - The issue with "Exception is raised when switching between the pages with SfToast Opened" has been resolved.


### PR DESCRIPTION
"Exception is raised when switching between the pages with SfToast Opened" release notes added