### PR TITLE
documentation(EJ2-52262): added example for the usage of methods like…

### DIFF
--- a/blazor/rich-text-editor/getting-started.md
+++ b/blazor/rich-text-editor/getting-started.md
@@ -290,6 +290,48 @@ To retrieve the editor contents, use the `Value` property of Rich Text Editor. T
 }
 ```
 
+## Retrieve the number of characters in the Rich Text Editor
+
+To retrieve the maximum number of characters in the Rich Text Editor's content, use the `GetCharCount` property of the Rich Text Editor.
+
+{% highlight razor %}
+
+@using Syncfusion.Blazor.Buttons
+@using Syncfusion.Blazor.RichTextEditor
+@using Syncfusion.Blazor.Popups
+
+<SfButton @onclick="@GetCharCount">Get Char Count</SfButton>
+
+<br />
+<SfDialog @ref="DialogObj" @bind-Visible="@Visibility" Content="@Content" Header="@Header" Target="#target" Height="200px"
+          Width="400px" ShowCloseIcon="true">
+    <DialogButtons>
+        <DialogButton Content="Ok" IsPrimary="true" OnClick="@DlgButtonClick" />
+    </DialogButtons>
+
+</SfDialog>
+<SfRichTextEditor @ref="RteObj" />
+
+@code {
+    SfRichTextEditor RteObj;
+    SfDialog DialogObj;
+    private string Content;
+    private bool Visibility = false;
+    private string Header = "RichTextEditor's Value";
+    private string RteValue = @"<p>Rich Text Editor allows to insert images from online source as well as local computer where you want to insert the image in your content.</p><p><b>Get started Quick Toolbar to click on the image</b></p><p>It is possible to add custom style on the selected image inside the Rich Text Editor through quick toolbar.</p><img alt='Logo' style='width: 300px; height: 300px; transform: rotate(0deg);' src='https://blazor.syncfusion.com/demos/images/RichTextEditor/RTEImage-Feather.png' />";
+    private async Task GetCharCount()
+    {
+        this.Content = await this.RteObj.GetCharCountAsync();
+        await this.DialogObj.ShowAsync();
+    }
+    private async Task DlgButtonClick(object arg)
+    {
+        await this.DialogObj.HideAsync();
+    }
+}
+
+{% endhighlight %}
+
 ## See Also
 
 * [Getting Started with Syncfusion Blazor for client-side in .NET Core CLI](../getting-started/blazor-webassembly-dotnet-cli/)


### PR DESCRIPTION
documentation(EJ2-52262): added example for the usage of methods like getCharCount in documentation pages(Blazor)