### PR TITLE
documentation(BLAZ-9039): RichTextEditor not rendered properly, if pl…

### DIFF
--- a/blazor-toc.html
+++ b/blazor-toc.html
@@ -2840,6 +2840,7 @@
 					<li> <a href="/blazor/rich-text-editor/how-to/placeholder">Customize placeholder style</a></li>
 					<li> <a href="/blazor/rich-text-editor/how-to/rename-image">Rename images before inserting it in Rich Text Editor</a></li>
 					<li> <a href="/blazor/rich-text-editor/how-to/format-code-block">Format code block using toolbar button</a></li>
+					<li> <a href="/blazor/rich-text-editor/how-to/rte-inside-dialog">RichTextEditor inside the Dialog component</a></li>
 				</ul>
 			</li>
 			<li>


### PR DESCRIPTION
documentation(BLAZ-9039): RichTextEditor not rendered properly, if placed inside an EJ2 Dialog.