### PR TITLE
documentation(EJ2-56305): Added missed keys in the Keyboard navigation section

### DIFF
--- a/blazor/scheduler/accessibility.md
+++ b/blazor/scheduler/accessibility.md
@@ -50,4 +50,4 @@ Interaction Keys |Description
 <kbd>Space</kbd> or <kbd>Enter</kbd> |It activates any of the focused items.
 <kbd>Page Up</kbd> & <kbd>Page Down</kbd> |To scroll through the work cells area.
 <kbd>Home</kbd> |To move the selection to the first cell of Scheduler.
-<kbd>F12</kbd> |To have the inline option for cells.
+<kbd>F12</kbd> |To have the inline option for both cells and events.

--- a/blazor/scheduler/accessibility.md
+++ b/blazor/scheduler/accessibility.md
@@ -35,9 +35,8 @@ Interaction Keys |Description
 -----|-----
 <kbd>Alt</kbd> + <kbd>j</kbd> |Focuses the Scheduler [Provided from application end].
 <kbd>Tab</kbd> |Focuses the first or active item on the scheduler header bar and then moves the focus to the next available event elements. If no events present, then focus moves out of the component.
-<kbd>Shift</kbd> + <kbd>Tab</kbd> |Reverse focusing of the Tab functionality. Inverse focusing of event elements from the last one and then move onto the first or active item on Scheduler header bar and then moves out of the component.
-<kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Arrow</kbd> (keys) |Focuses the event element and then move the focus to the next available event elements between the resources.
-<kbd>Enter</kbd> |Opens the quick popup on the selected cells or events.
+<kbd>Shift</kbd> + <kbd>Tab</kbd> |Reverse focusing of the Tab functionality. Inverse focusing of event elements from the last one and then moves onto the first or active item on Scheduler header bar and then moves out of the component.
+<kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Arrow</kbd> (keys) |Focuses the event element and then moves the focus to the next available event elements between the resources.
 <kbd>Escape</kbd> |Closes any of the popup that are in open state.
 <kbd>Arrow</kbd> |To move onto the next available cells in either of the needed directions (left, right, top and right)
 <kbd>Shift</kbd> + <kbd>Arrow</kbd> |For multiple cell selection on either direction.

--- a/blazor/scheduler/accessibility.md
+++ b/blazor/scheduler/accessibility.md
@@ -36,6 +36,7 @@ Interaction Keys |Description
 <kbd>Alt</kbd> + <kbd>j</kbd> |Focuses the Scheduler [Provided from application end].
 <kbd>Tab</kbd> |Focuses the first or active item on the scheduler header bar and then move the focus to the next available event elements. If no events present, then focus moves out of the component.
 <kbd>Shift</kbd> + <kbd>Tab</kbd> |Reverse focusing of the Tab functionality. Inverse focusing of event elements from the last one and then move onto the first or active item on Scheduler header bar and then moves out of the component.
+<kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Arrow</kbd> (keys) |Focuses the event element and then move the focus to the next available event elements between the resources.
 <kbd>Enter</kbd> |Opens the quick popup on the selected cells or events.
 <kbd>Escape</kbd> |Closes any of the popup that are in open state.
 <kbd>Arrow</kbd> |To move onto the next available cells in either of the needed directions (left, right, top and right)
@@ -49,3 +50,4 @@ Interaction Keys |Description
 <kbd>Space</kbd> or <kbd>Enter</kbd> |It activates any of the focused items.
 <kbd>Page Up</kbd> & <kbd>Page Down</kbd> |To scroll through the work cells area.
 <kbd>Home</kbd> |To move the selection to the first cell of Scheduler.
+<kbd>F12</kbd> |To have the inline option for cells.

--- a/blazor/scheduler/accessibility.md
+++ b/blazor/scheduler/accessibility.md
@@ -34,7 +34,7 @@ All the Scheduler actions can be controlled via keyboard keys and is availed by 
 Interaction Keys |Description
 -----|-----
 <kbd>Alt</kbd> + <kbd>j</kbd> |Focuses the Scheduler [Provided from application end].
-<kbd>Tab</kbd> |Focuses the first or active item on the scheduler header bar and then move the focus to the next available event elements. If no events present, then focus moves out of the component.
+<kbd>Tab</kbd> |Focuses the first or active item on the scheduler header bar and then moves the focus to the next available event elements. If no events present, then focus moves out of the component.
 <kbd>Shift</kbd> + <kbd>Tab</kbd> |Reverse focusing of the Tab functionality. Inverse focusing of event elements from the last one and then move onto the first or active item on Scheduler header bar and then moves out of the component.
 <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Arrow</kbd> (keys) |Focuses the event element and then move the focus to the next available event elements between the resources.
 <kbd>Enter</kbd> |Opens the quick popup on the selected cells or events.


### PR DESCRIPTION
Ctrl + Shift + Arrow keys and F12 functionality were not added in the below UG.

https://blazor.syncfusion.com/documentation/scheduler/accessibility#keyboard-navigation