### PR TITLE
Correct wrong highlighted line

### DIFF
--- a/blazor/common/adding-script-references.md
+++ b/blazor/common/adding-script-references.md
@@ -75,7 +75,7 @@ namespace BlazorApplication
 For Blazor WebAssembly App, set [IgnoreScriptIsolation](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.GlobalOptions.html#Syncfusion_Blazor_GlobalOptions_IgnoreScriptIsolation) property as `true` using `AddSyncfusionBlazor` service method in `~/Program.cs` file.
 
 {% tabs %}
-{% highlight c# tabtitle=".NET 6 (~/Program.cs)" hl_lines="9" %}
+{% highlight c# tabtitle=".NET 6 (~/Program.cs)" hl_lines="11" %}
 
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;


### PR DESCRIPTION
In the .NET 6 example of the Blazor WASM instructions, the set IgnoreScriptIsolation line is not highlighted, instead the preious line is.