### PR TITLE
bug(BLAZ-21578): Limitations

### DIFF
--- a/blazor/gantt-chart/virtual.md
+++ b/blazor/gantt-chart/virtual.md
@@ -161,3 +161,4 @@ namespace GanttComponent.Data
 * Cell selection will not be persisted in a row.
 * Programmatic selection using the **SelectRows** method is not supported in virtual scrolling.
 * Currently Editing, Row Drag and Drop are not supported with Virtual scrolling.
+* Collapse all tasks and Expand all tasks are not supported with Virtual scrolling.

--- a/blazor/gantt-chart/virtual.md
+++ b/blazor/gantt-chart/virtual.md
@@ -161,4 +161,4 @@ namespace GanttComponent.Data
 * Cell selection will not be persisted in a row.
 * Programmatic selection using the **SelectRows** method is not supported in virtual scrolling.
 * Currently Editing, Row Drag and Drop are not supported with Virtual scrolling.
-* Collapse all tasks and Expand all tasks are not supported with Virtual scrolling.
+* Collapse all and expand all actions are performed only for the current view-port data in virtual scrolling.


### PR DESCRIPTION
Limitations added for Virtual Scroll in Blazor Gantt Chart Component.

Limitations added
- Collapse all tasks and Expand all tasks are not supported with Virtual scrolling.