### PR TITLE
Info to help SortComparer work in certain cases.

### DIFF
--- a/blazor/datagrid/sorting.md
+++ b/blazor/datagrid/sorting.md
@@ -271,6 +271,7 @@ The following GIF represents custom SortComparer for CustomerID column. When the
 ![Custom sort comparer in Blazor DataGrid](./images/blazor-datagrid-custom-sort-comparer.gif)
 
 > The SortComparer property will work only for local data.
+> If you're using a Template to display the data in a column, you still need the Field parameter in GridColumn -- it's required in order for SortComparer to work.
 
 ## Touch interaction
 


### PR DESCRIPTION
According to my testing, the Field parameter in GridColumn is required for SortComparer to work. This is true even if you're using a Template to actually show the data for that grid column.