### PR TITLE
documentation(EJ2-62728): link does not navigate to the another page issue has been resolved.

### DIFF
--- a/blazor/carousel/populating-items.md
+++ b/blazor/carousel/populating-items.md
@@ -299,4 +299,4 @@ The following example code depicts the functionality of `partialVisible` and wit
 
 ## See Also
 
-* [Customizing partial slides area size](../carousel/styles-and-appearance.md)
+* [Customizing partial slides area size](./styles-and-appearance/#customizing-partial-slides-size)


### PR DESCRIPTION
Reference link does not navigate to the another page issue has been resolved.