### PR TITLE
config(BLAZ-26136): corrected the documentaion by replacing OrdersDetailsContext with LibraryContext

### DIFF
--- a/blazor/common/data-binding/bind-entity-framework.md
+++ b/blazor/common/data-binding/bind-entity-framework.md
@@ -95,7 +95,7 @@ Now, the **DbContext** must be configured using connection string and registered
 {% tabs %}
 {% highlight c# tabtitle=".NET 6 (~/Program.cs)" %}
 
-builder.Services.AddDbContext<OrdersDetailsContext>(option =>
+builder.Services.AddDbContext<LibraryContext>(option =>
                 option.UseSqlServer(builder.Configuration.GetConnectionString("LibraryDatabase")));
 
 {% endhighlight %}
@@ -116,7 +116,7 @@ namespace ODataServiceProject
         public void ConfigureServices(IServiceCollection services)
         {
             
-            services.AddDbContext<OrdersDetailsContext>(option => 
+            services.AddDbContext<LibraryContext>(option => 
                 option.UseSqlServer(Configuration.GetConnectionString("LibraryDatabase")));
             ...
         }
@@ -232,7 +232,7 @@ Now, you need to register the **LibraryService** and **ILibraryService** as serv
 {% highlight c# tabtitle=".NET 6 (~/Program.cs)" %}
 
 builder.Services.AddScoped<ILibraryService, LibraryService>();
-builder.Services.AddDbContext<OrdersDetailsContext>(option =>
+builder.Services.AddDbContext<LibraryContext>(option =>
                 option.UseSqlServer(builder.Configuration.GetConnectionString("LibraryDatabase")));
 
 {% endhighlight %}
@@ -253,7 +253,7 @@ namespace ODataServiceProject
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddScoped<ILibraryService, LibraryService>();            
-            services.AddDbContext<OrdersDetailsContext>(option => 
+            services.AddDbContext<LibraryContext>(option => 
                 option.UseSqlServer(Configuration.GetConnectionString("LibraryDatabase")));
             ...
         }


### PR DESCRIPTION
**Root:**
OrdersDetailsContext throws error.
![image](https://user-images.githubusercontent.com/103921986/194571874-f8424c90-21da-46b5-bb02-677a55273ddd.png)

**Solution:**
https://blazor.syncfusion.com/documentation/common/data-binding/bind-entity-framework?cs-save-lang=1&cs-lang=csharp - According to this documentation if we create a sample the DbContext is inherited in LibraryContext.cs so we're supposed to use LibraryContext for registering but in the documentation for registering DbContext, OrderDetailsContext has been used, which doesn't exist, that is why it throws error.