### PR TITLE
bug(BLAZ-27217):removed

### DIFF
--- a/blazor/treegrid/how-to/single-click-editing-with-batch-mode.md
+++ b/blazor/treegrid/how-to/single-click-editing-with-batch-mode.md
@@ -28,8 +28,7 @@ Set the [Mode](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.TreeGrid.
     <TreeGridColumns>
         <TreeGridColumn Field="TaskId" HeaderText="Task ID" IsPrimaryKey="true" Width="70" TextAlign="TextAlign.Right"></TreeGridColumn>
         <TreeGridColumn Field="TaskName" HeaderText="Task Name" Width="85"></TreeGridColumn>
-        <TreeGridColumn Field="Resources" HeaderText="Resource" Width="70" TextAlign="TextAlign.Right"></TreeGridColumn>
-        <TreeGridColumn Field="Duration" HeaderText="Duation" Width="70" TextAlign="TextAlign.Right"></TreeGridColumn>
+        <TreeGridColumn Field="Duration" HeaderText="Duration" Width="70" TextAlign="TextAlign.Right"></TreeGridColumn>
         <TreeGridColumn Field="Progress" HeaderText="Progress" Width="70" TextAlign="TextAlign.Right"></TreeGridColumn>
         <TreeGridColumn Field="Priority" HeaderText="Priority" Width="70"></TreeGridColumn>
     </TreeGridColumns>


### PR DESCRIPTION
Bug description
Didn't work for toolbar item in Single click editing with batch mode

Root cause
There is no property declared for a particular field that leads to Argument exception and prevent the program to enable update in ToolBar

Reason for not identifying earlier
Find how it was missed in our earlier testing and development by analysing the below checklist. This will help prevent similar mistakes in the future.

 Guidelines/documents are not followed

Common guidelines / Core team guideline
Specification document
Requirement document
 Guidelines/documents are not given

Common guidelines / Core team guideline
Specification document
Requirement document
Reason:
Specification document

Output screenshots:

![SingleClick_Batch](https://user-images.githubusercontent.com/115706457/209946261-280b857a-b730-4a36-bba3-6bf0e4f923b4.jpg)


Action taken:
Ensured the sample with changes made

Related areas:
Blazor Documentation

Is it a breaking issue?
No

Solution description
since the field has no property and it was not necessary. so, I removed that particular field and ensured the fix for that sample

Areas affected and ensured
Checked through the console.

Additional checklist
This may vary for different teams or products. Check with your scrum masters.

Did you run the automation against your fix? No-Assigned to Testing team
Is there any API name change? NO
Is there any existing behavior change of other features due to this code change? NO
Does your new code introduce new warnings or binding errors? No
Does your code pass all FxCop and StyleCop rules? NO
Did you record this case in the unit test or UI test? No