### PR TITLE
BLAZ-28030 : Additional information's were added

### DIFF
--- a/blazor/tooltip/getting-started.md
+++ b/blazor/tooltip/getting-started.md
@@ -289,7 +289,7 @@ N> Syncfusion recommends to reference scripts using [Static Web Assets](https://
 
 ![Blazor Tooltip Component](./images/blazor-tooltip.gif)
 
-N>[View Sample in GitHub](https://github.com/SyncfusionExamples/Blazor-Getting-Started-Examples/tree/main/Tooltip).
+N> The Tooltip component in our system uses the HTML element's id or class name to identify the target for the tooltip. However, when using a GUID as the target ID, it is not able to recognize IDs that start with a digit. <br/>[View Sample in GitHub](https://github.com/SyncfusionExamples/Blazor-Getting-Started-Examples/tree/main/Tooltip).
 
 ## See Also
 

--- a/blazor/tooltip/getting-started.md
+++ b/blazor/tooltip/getting-started.md
@@ -289,7 +289,7 @@ N> Syncfusion recommends to reference scripts using [Static Web Assets](https://
 
 ![Blazor Tooltip Component](./images/blazor-tooltip.gif)
 
-N> The Tooltip component in our system uses the HTML element's id or class name to identify the target for the tooltip. However, when using a GUID as the target ID, it is not able to recognize IDs that start with a digit. <br/>[View Sample in GitHub](https://github.com/SyncfusionExamples/Blazor-Getting-Started-Examples/tree/main/Tooltip).
+N> [View Sample in GitHub](https://github.com/SyncfusionExamples/Blazor-Getting-Started-Examples/tree/main/Tooltip).
 
 ## See Also
 

--- a/blazor/tooltip/getting-started.md
+++ b/blazor/tooltip/getting-started.md
@@ -289,7 +289,7 @@ N> Syncfusion recommends to reference scripts using [Static Web Assets](https://
 
 ![Blazor Tooltip Component](./images/blazor-tooltip.gif)
 
-N> [View Sample in GitHub](https://github.com/SyncfusionExamples/Blazor-Getting-Started-Examples/tree/main/Tooltip).
+N> The Tooltip component in our system uses the HTML element's id or class name to identify the target for the tooltip. However, when using a GUID as the target ID, it is not able to recognize IDs that start with a digit. <br/>[View Sample in GitHub](https://github.com/SyncfusionExamples/Blazor-Getting-Started-Examples/tree/main/Tooltip).
 
 ## See Also
 

--- a/blazor/tooltip/getting-started.md
+++ b/blazor/tooltip/getting-started.md
@@ -289,7 +289,7 @@ N> Syncfusion recommends to reference scripts using [Static Web Assets](https://
 
 ![Blazor Tooltip Component](./images/blazor-tooltip.gif)
 
-N> The Tooltip component in our system uses the HTML element's id or class name to identify the target for the tooltip. However, when using a GUID as the target ID, it is not able to recognize IDs that start with a digit. <br/>[View Sample in GitHub](https://github.com/SyncfusionExamples/Blazor-Getting-Started-Examples/tree/main/Tooltip).
+N>[View Sample in GitHub](https://github.com/SyncfusionExamples/Blazor-Getting-Started-Examples/tree/main/Tooltip).
 
 ## See Also
 


### PR DESCRIPTION
In our Tooltip component, the Tooltip target is taken based on the HTML elements id or class name. When using the GUID as the target id for a tooltip, it is not possible to obtain an ID that begins with a digit. This is the current behavior of Tooltip component. 
So, I have added the additional information about Tooltip Target property