### PR TITLE
SEO-175881: Corrected page not found link issue in Blazor doc

### DIFF
--- a/blazor/common/how-to/create-blazor-webassembly-prerendering.md
+++ b/blazor/common/how-to/create-blazor-webassembly-prerendering.md
@@ -17,7 +17,7 @@ This section explains how to enable prerendering to a Blazor WebAssembly applica
 
 ## Create a new project for Blazor WebAssembly ASP.NET Core Hosted application
 
-1. Create a new [Blazor WebAssembly ASP.NET Core Hosted application](../../visual-studio-2019/#create-a-new-project-for-blazor-webassembly-aspnet-core-hosted-application).
+1. Create a new [Blazor WebAssembly ASP.NET Core Hosted application](https://blazor.syncfusion.com/documentation/getting-started/blazor-core-hosted#create-a-blazor-aspnet-core-hosted-webassembly-app-in-visual-studio).
 
 2. Delete `~/wwwroot/index.html` file in the Client project.
 

--- a/blazor/diagram/connectors/segments/segments.md
+++ b/blazor/diagram/connectors/segments/segments.md
@@ -403,8 +403,8 @@ You can download a complete working sample from [GitHub](https://github.com/Sync
 
 ## See also
 
-* [How to customize the connector properties](./customization)
+* [How to customize the connector properties](https://blazor.syncfusion.com/documentation/diagram/connectors/customization)
 
-* [How to interact with the connector](./interactions)
+* [How to interact with the connector](https://blazor.syncfusion.com/documentation/diagram/connectors/interactions)
 
-* [How to get the connector events](./events)
+* [How to get the connector events](https://blazor.syncfusion.com/documentation/diagram/connectors/events)

--- a/blazor/scheduler/crud-actions.md
+++ b/blazor/scheduler/crud-actions.md
@@ -507,7 +507,7 @@ if (param.action == "remove" || (param.action == "batch" && param.deleted != nul
 }
 ```
 
-N> To know more about handling recurrence exceptions, refer the [Adding exceptions](./recurring-events.md/#adding-exceptions) topic.
+N> To know more about handling recurrence exceptions, refer the [Adding exceptions](https://blazor.syncfusion.com/documentation/scheduler/recurring-events#adding-exceptions) topic.
 
 ### Restricting edit action based on specific criteria
 

--- a/blazor/scheduler/working-hours.md
+++ b/blazor/scheduler/working-hours.md
@@ -102,7 +102,7 @@ Here, the working days are defined as [1, 3, 4, 5] on Scheduler and therefore th
 
 It is possible to show the week number count of a week in the header bar of the Scheduler by setting true to the `ShowWeekNumber` property. By default, its default value is `false`. In Month view, the week numbers are displayed as a first column.
 
-N> The `ShowWeekNumber` property is not applicable on Timeline views, as it has the equivalent [HeaderRows](./header-rows/#display-week-numbers-in-timeline-views) property to handle such requirement with additional customization.
+N> The `ShowWeekNumber` property is not applicable on Timeline views, as it has the equivalent [HeaderRows](./header-rows#display-week-numbers-in-timeline-views) property to handle such requirement with additional customization.
 
 ```cshtml
 @using Syncfusion.Blazor.Schedule


### PR DESCRIPTION
Hi @Aishwarya-Ganesan 

I have corrected the invalid links in our Blazor doc pages. Please check and merge the changes.

Thanks,
Mallika