### PR TITLE
documentation(855465): ExpandoObject

### DIFF
--- a/blazor/gantt-chart/data-binding.md
+++ b/blazor/gantt-chart/data-binding.md
@@ -225,10 +225,11 @@ ExpandoObject can be bound to Gantt by assigning to the `DataSource` property. G
 ```cshtml
 
 @using Syncfusion.Blazor.Gantt
+@using System.Dynamic;
 
 <SfGantt TValue="ExpandoObject" DataSource="@TreeData" @ref="Gantt" Height="450px" Width="700px">
     <GanttTaskFields Id="TaskID" Name="TaskName" StartDate="StartDate" Duration="Duration"
-        Progress="Progress" ParentID="ParentID">
+                     Progress="Progress" ParentID="ParentID">
     </GanttTaskFields>
     <GanttEditSettings AllowAdding="true" AllowDeleting="true" AllowEditing="true" AllowTaskbarEditing="true"></GanttEditSettings>
 </SfGantt>
@@ -284,16 +285,7 @@ ExpandoObject can be bound to Gantt by assigning to the `DataSource` property. G
             Data.Add(ChildRecord);
         }
     }
-    public class ExpandoObject
-    {
-        public int TaskID { get; set; }
-        public string TaskName { get; set; }
-        public DateTime? StartDate { get; set; }
-        public DateTime? EndDate { get; set; }
-        public int Progress { get; set; }
-        public string Duration { get; set; }
-        public int? ParentID { get; set; }
-    }
+    
 }
 ```
 


### PR DESCRIPTION
Removed self referring ExpandoObject class and used used in build ExpandoObject binding 