### PR TITLE
UG(857488) - Updated outdated HtmlAttribute link in Button UG

### DIFF
--- a/blazor/button/how-to/html-attribute-support.md
+++ b/blazor/button/how-to/html-attribute-support.md
@@ -1,27 +1,32 @@
 ---
 layout: post
-title: Tooltip for Button in Blazor Button Component | Syncfusion
-description: Checkout and learn here all about Tooltip for Button in Syncfusion Blazor Button component and more.
+title: HTML Attribute Support in Blazor Button Component | Syncfusion
+description: Checkout and learn here all about HTML Attribute Support in Syncfusion Blazor Button component and more.
 platform: Blazor
 control: Button
 documentation: ug
 ---
 
-# Tooltip for Button in Blazor Button Component
+# HTML Attribute Support in Blazor Button Component
 
-Tooltip can be shown on Button hover and it can be achieved by title attribute.
+HTML attribute support is given for button using [HtmlAttributes](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.Buttons.SfButton.html) property.
 
 ```csharp
 
 @using Syncfusion.Blazor.Buttons
 
-<SfButton Content="@Content" title="Primary Button" IsPrimary="true"></SfButton>
+<SfButton Content="@Content" HtmlAttributes="@submit"></SfButton>
 
 @code {
-    public string Content = "Button";
+    public string Content = "Submit";
+    private Dictionary<string, object> submit = new Dictionary<string, object>()
+     {
+        { "type", "submit"},
+        { "title", "Primary Button" }
+    };
 }
 
 ```
 
 
-![Blazor Button displays ToolTip](./../images/blazor-button-tooltip.png)
+![Blazor Button with HTML Attribute](./../images/blazor-button-with-html.png)

--- a/blazor/button/how-to/html-attribute-support.md
+++ b/blazor/button/how-to/html-attribute-support.md
@@ -1,32 +1,27 @@
 ---
 layout: post
-title: HTML Attribute Support in Blazor Button Component | Syncfusion
-description: Checkout and learn here all about HTML Attribute Support in Syncfusion Blazor Button component and more.
+title: Tooltip for Button in Blazor Button Component | Syncfusion
+description: Checkout and learn here all about Tooltip for Button in Syncfusion Blazor Button component and more.
 platform: Blazor
 control: Button
 documentation: ug
 ---
 
-# HTML Attribute Support in Blazor Button Component
+# Tooltip for Button in Blazor Button Component
 
-HTML attribute support is given for button using [HtmlAttributes](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.Buttons.SfButton.html) property.
+Tooltip can be shown on Button hover and it can be achieved by title attribute.
 
 ```csharp
 
 @using Syncfusion.Blazor.Buttons
 
-<SfButton Content="@Content" HtmlAttributes="@submit"></SfButton>
+<SfButton Content="@Content" title="Primary Button" IsPrimary="true"></SfButton>
 
 @code {
-    public string Content = "Submit";
-    private Dictionary<string, object> submit = new Dictionary<string, object>()
-     {
-        { "type", "submit"},
-        { "title", "Primary Button" }
-    };
+    public string Content = "Button";
 }
 
 ```
 
 
-![Blazor Button with HTML Attribute](./../images/blazor-button-with-html.png)
+![Blazor Button displays ToolTip](./../images/blazor-button-tooltip.png)

--- a/blazor/button/how-to/tooltip-for-button.md
+++ b/blazor/button/how-to/tooltip-for-button.md
@@ -9,20 +9,16 @@ documentation: ug
 
 # Tooltip for Button in Blazor Button Component
 
-Tooltip can be shown on Button hover and it can be achieved by [HtmlAttributes](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.Buttons.SfButton.html) property.
+Tooltip can be shown on Button hover and it can be achieved by title attribute.
 
 ```csharp
 
 @using Syncfusion.Blazor.Buttons
 
-<SfButton Content="@Content" HtmlAttributes="@primButton" IsPrimary="true"></SfButton>
+<SfButton Content="@Content" title="Primary Button" IsPrimary="true"></SfButton>
 
 @code {
     public string Content = "Button";
-    private Dictionary<string, object> primButton = new Dictionary<string, object>()
-    {
-        { "title", "Primary Button"}
-    };
 }
 
 ```


### PR DESCRIPTION
### Bug description

HtmlAttribute link was outdated  in Button UG

### Root cause

Button component component there is no HtmlAttribute property and it can be used direct button tag

#### Reason for not identifying earlier

Not consider Earlier

### Action taken:

HtmlAttributes was directly assigned to button tag

### Related areas:

-NA

### Is it a breaking issue?

No

### Solution description

HtmlAttributes was directly assigned to button tag
 

### Areas affected and ensured

- HtmlAttribute

### Additional checklist

- Did you run the automation against your fix - Yes

- Is there any API name change - No

- Is there any existing behavior change of other features due to this code change - No

- Does your new code introduce new warnings or binding errors - NA

- Does your code pass all FxCop and StyleCop rules - NA

- Did you record this case in the unit test or UI test or B-unit
	- [ ] Unit testing
	- [x] B-Unit - Assigned to testing team
	- [ ] E2E - Assigned to testing team