### PR TITLE
Task 855214: To add the Colorpicker documentation, if the noColor property is set to true, we need to ensure that the modeswitcher property is set to false.

### DIFF
--- a/blazor/color-picker/how-to/no-color-support.md
+++ b/blazor/color-picker/how-to/no-color-support.md
@@ -43,6 +43,8 @@ To achieve this, set [NoColor](https://help.syncfusion.com/cr/blazor/Syncfusion.
 
 ![Blazor ColorPicker with Default No Color](./../images/blazor-colorpicker-nocolor.png)
 
+>if the noColor property is set to true, ensure that the modeswitcher property is set to false.
+
 ## Custom no color
 
 The following sample shows the color palette with custom no color option.

--- a/blazor/color-picker/how-to/no-color-support.md
+++ b/blazor/color-picker/how-to/no-color-support.md
@@ -43,7 +43,7 @@ To achieve this, set [NoColor](https://help.syncfusion.com/cr/blazor/Syncfusion.
 
 ![Blazor ColorPicker with Default No Color](./../images/blazor-colorpicker-nocolor.png)
 
->if the noColor property is set to true, ensure that the modeswitcher property is set to false.
+>If the [NoColor](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.Inputs.SfColorPicker.html#Syncfusion_Blazor_Inputs_SfColorPicker_NoColor) property is enabled, make sure to disable the [ModeSwitcher](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.Inputs.SfColorPicker.html#Syncfusion_Blazor_Inputs_SfColorPicker_ModeSwitcher) property.
 
 ## Custom no color
 


### PR DESCRIPTION
### Bug description

To add the Colorpicker documentation, if the noColor property is set to true, we need to ensure that the modeswitcher property is set to

### Root cause

NA

#### Reason for not identifying earlier

Find how it was missed in our earlier testing and development by analyzing the below checklist. This will help prevent similar mistakes in the future.
- [x] Guidelines/documents are not followed
- [ ] Common guidelines / Core team guideline
- [ ] Specification document
- [ ] Requirement document

### Action taken:

Added in color picker documentation to ensure mode switcher property is false when no color property is set to true

### Related areas:

UG documentation

### Is it a breaking issue?

no

### Solution description

Added in color picker documentation to ensure mode switcher property is false when no color property is set to true

### Areas affected and ensured

Color picker ug documentation
