### PR TITLE
documentation(856202): Need to add notes section for "Can't find stylesheet to import" error when installing blazor theme

### DIFF
--- a/blazor/appearance/themes.md
+++ b/blazor/appearance/themes.md
@@ -304,6 +304,8 @@ You can add the `SCSS theme` for Blazor applications through NPM package and com
 
 N> If you are using **Visual Studio 2019**, please use the `includePath` property instead of `loadPaths` as the latter does not support the Web Compiler for VS 2019. However, we highly recommend using the **Web Compiler 2022+** for **Visual Studio 2022**. For more information, please refer to the [discussion link here](https://github.com/failwyn/WebCompiler/issues/24).
 
+N> If you come across the **'Can't find stylesheet to import'** error, ensure that you have installed the [Syncfusion Blazor Themes](https://www.npmjs.com/package/@syncfusion/blazor-themes) NPM package in the project's directory rather than the solution's directory.
+
 The following shows the importing theme path for the overall theme.
 
 ```css


### PR DESCRIPTION
**Root:**

Need to add notes section for "Can't find stylesheet to import" error when installing blazor theme.

**Solution:**

The notes section for "Can't find stylesheet to import" error has been added.