### PR TITLE
bug(859722): Console error occurs when editing taskname in observable collection sample

### DIFF
--- a/blazor/gantt-chart/data-binding.md
+++ b/blazor/gantt-chart/data-binding.md
@@ -518,7 +518,7 @@ In the below example, `TaskData` implements `INotifyPropertyChanged` and it rais
     public class TaskData : INotifyPropertyChanged
     {
         public int TaskId { get; set; }
-        public string taskName { get; set; }
+        private string taskName { get; set; }
         public string TaskName
         {
             get { return taskName; }


### PR DESCRIPTION
Changed the access modifier to the taskName property.