### PR TITLE
documentation(ES-863462): Need to change the image URL link in the Blazor Tooltip template documentation sample 

### DIFF
--- a/blazor/tooltip/template.md
+++ b/blazor/tooltip/template.md
@@ -27,7 +27,7 @@ Refer to the following code example to add and display a HTML page to the Toolti
                         The<a href='https://en.wikipedia.org/wiki/Eastern_bluebird' target='blank'> Eastern Bluebird</a>
                         is easily found in open fields and sparse woodland areas, including along woodland edges.These are<i>cavity-nesting birds</i>and a pair of eastern bluebirds will raise 2-3 broods annually, with 2-8 light blue or whitish eggs per brood.
                     </div>
-                    <div id='bird' style='float:right;width:42%'><img src='https://blazor.syncfusion.com/demos/css/tooltip/bird.png' width='125' height='125' /></div>
+                    <div id='bird' style='float:right;width:42%'><img src='https://blazor.syncfusion.com/demos/_content/blazor_webapp_common_net8/images/tooltip/bird.png' width='125' height='125' /></div>
                 </div>
                 <div style='margin-top:160px'>
                     <hr><p style='margin-top:-11px'> Eastern bluebirds can be very vocal in flocks.Their calls include a rapid, mid-tone chatter and several long dropping pitch calls.</p>


### PR DESCRIPTION
I have changed the image URL link in the Blazor Tooltip template documentation sample. 