### PR TITLE
Blazor-869969-Need to modify the code to avoid displaying the warning BL0005 when using the grid instance searchsettings.key.

### DIFF
--- a/blazor/datagrid/searching.md
+++ b/blazor/datagrid/searching.md
@@ -681,7 +681,7 @@ The following example demonstrates, how to perform a search with multiple keywor
 @using Syncfusion.Blazor.Data
 
 <SfTextBox Input="OnInput"></SfTextBox>
-<SfRadioButton TChecked="bool" ValueChange="DariRadioButton" Label="Lucas"></SfRadioButton>
+<SfRadioButton TChecked="bool" ValueChange="OnRadioButtonChecked" Label="Lucas"></SfRadioButton>
 
 <SfGrid @ref="DefaultGrid" DataSource="@Orders" Query="@SearchQuery">
     <GridColumns>
@@ -713,7 +713,7 @@ The following example demonstrates, how to perform a search with multiple keywor
         SearchQuery = new Query().Where(ColumnPredicate);
     }
 
-    public void DariRadioButton(ChangeArgs<bool> pilihan)
+    public void OnRadioButtonChecked(ChangeArgs<bool> pilihan)
     {
         Predicate.Add(new WhereFilter()
             {

--- a/blazor/datagrid/searching.md
+++ b/blazor/datagrid/searching.md
@@ -18,7 +18,6 @@ To further enhance the search functionality, you can integrate a search text box
 {% tabs %}
 {% highlight razor tabtitle="Index.razor" %}
 @using Syncfusion.Blazor.Grids
-@using BlazorApp1.Data
 
 <SfGrid DataSource="@Orders" Toolbar=@ToolbarItems>
     <GridColumns>
@@ -120,7 +119,6 @@ The following example demonstrates how to set an initial search in the grid usin
 {% tabs %}
 {% highlight razor tabtitle="Index.razor" %}
 @using Syncfusion.Blazor.Grids
-@using BlazorApp1.Data
 
 <SfGrid DataSource="@Orders" Toolbar=@ToolbarItems>
     <GridSearchSettings Fields=@InitSearch Operator=Syncfusion.Blazor.Operator.Contains Key="Ha" IgnoreCase="true"></GridSearchSettings>
@@ -217,7 +215,6 @@ The following example demonstrates how to set the `SearchSettings.Operator` prop
 {% highlight razor tabtitle="Index.razor" %}
 @using Syncfusion.Blazor.Grids
 @using Syncfusion.Blazor.DropDowns
-@using BlazorApp1.Data
 
 <label>Change the search operators: </label>
 <SfDropDownList Width="100px" TValue="Operator" TItem="DropDownOrder" Value="@SearchOperator" DataSource="@DropDownData">
@@ -332,7 +329,6 @@ The ```SearchAsync``` method allows you to perform a search operation based on a
 @using Syncfusion.Blazor.Grids
 @using Syncfusion.Blazor.Inputs
 @using Syncfusion.Blazor.Buttons
-@using BlazorApp1.Data
 
 <SfTextBox @ref="TextBox" Placeholder="Search" Width="200px"></SfTextBox>
 <SfButton Content="Search" OnClick="SearchBtnHandler"></SfButton>
@@ -420,7 +416,6 @@ The following example demonstrates how to search specific columns such as **Cust
 {% tabs %}
 {% highlight razor tabtitle="Index.razor" %}
 @using Syncfusion.Blazor.Grids
-@using BlazorApp1.Data
 
 <SfGrid DataSource="@Orders" Toolbar=@ToolbarItems>
     <GridSearchSettings Fields=@SpecificColumns></GridSearchSettings>
@@ -501,8 +496,6 @@ In the below code example, the **Order ID** column search functionality is disab
 {% tabs %}
 {% highlight razor tabtitle="Index.razor" %}
 @using Syncfusion.Blazor.Grids
-@using BlazorApp1.Data
-
 
 <SfGrid DataSource="@Orders" Toolbar=@ToolbarItems>
     <GridColumns>
@@ -584,7 +577,6 @@ By default, the datagrid will initiate searching operation after the Enter key i
 @using Syncfusion.Blazor.Grids
 @using Syncfusion.Blazor.Inputs
 @using Syncfusion.Blazor.Navigations
-@using BlazorApp1.Data
 
 <SfGrid @ref="DefaultGrid" DataSource="@Orders" AllowSorting="true" AllowPaging="true">
     <SfToolbar>
@@ -687,7 +679,6 @@ The following example demonstrates, how to perform a search with multiple keywor
 @using Syncfusion.Blazor.Inputs
 @using Syncfusion.Blazor.Buttons
 @using Syncfusion.Blazor.Data
-@using BlazorApp1.Data
 
 <SfTextBox Input="OnInput"></SfTextBox>
 <SfRadioButton TChecked="bool" ValueChange="DariRadioButton" Label="Lucas"></SfRadioButton>
@@ -804,7 +795,6 @@ The following example demonstrates how to clear the searched records using an ex
 {% highlight razor tabtitle="Index.razor" %}
 @using Syncfusion.Blazor.Buttons
 @using Syncfusion.Blazor.Grids
-@using BlazorApp1.Data
 
 <SfButton Content="ClearSearch" OnClick="clearSearchBtnHandler"></SfButton>
 <SfGrid @ref="DefaultGrid" DataSource="@Orders" AllowSorting="true" Toolbar=@ToolbarItems>
@@ -827,7 +817,9 @@ The following example demonstrates how to clear the searched records using an ex
     }  
     public void clearSearchBtnHandler()
     {
+#pragma warning disable BL0005
         this.DefaultGrid.SearchSettings.Key = "";
+#pragma warning restore BL0005
         DefaultGrid.Refresh();
     }     
 }


### PR DESCRIPTION
Add the line to disable the warning and remove the unnecessary reference code

Content location:https://blazor.syncfusion.com/documentation/datagrid/searching