### PR TITLE
UG(ES-861836):  Clicked is spelled wrong in this event handler.

### DIFF
--- a/blazor/scheduler/editor-template.md
+++ b/blazor/scheduler/editor-template.md
@@ -470,6 +470,7 @@ In this demo, we tailor the editor's header according to the appointment's subje
     }
 </style>
 ```
+
 ![Add customize header and footer using template in Blazor Scheduler](images/blazor-scheduler-custom-editor-header-footer.png)
 
 ### How to add resource options within editor template
@@ -1693,7 +1694,7 @@ It is possible to prevent the display of popup window by passing the value `true
        <ScheduleViews>
            <ScheduleView Option="View.Month"></ScheduleView>
        </ScheduleViews>
-    <ScheduleEvents TValue="AppointmentData" MoreEventsClicked="OnMoreEventsCliecked"></ScheduleEvents>
+    <ScheduleEvents TValue="AppointmentData" MoreEventsClicked="OnMoreEventsClicked"></ScheduleEvents>
 </SfSchedule>
 
 @code{
@@ -1702,7 +1703,7 @@ It is possible to prevent the display of popup window by passing the value `true
 
     private DateTime SelectedDate = new DateTime(2020, 1, 31);
 
-    private void OnMoreEventsCliecked(MoreEventsClickArgs args)
+    private void OnMoreEventsClicked(MoreEventsClickArgs args)
     {
         args.Cancel = true;
     }


### PR DESCRIPTION
UG(ES-861836):  Clicked is spelled wrong in this event handler.

MoreEventsClicked="OnMoreEventsCliecked" Clicked is spelled wrong in this event handler



URL: https://blazor.syncfusion.com/documentation/scheduler/editor-template#how-to-prevent-the-display-of-popup-when-clicking-on-the-more-text-indicator