### PR TITLE
883058: Need to update the sample code snippet for state persistence in the Blazor Pivot Table

### DIFF
--- a/blazor/pivot-table/state-persistence.md
+++ b/blazor/pivot-table/state-persistence.md
@@ -82,6 +82,7 @@ You can save the current layout of the pivot table by using [GetPersistDataAsync
 </SfPivotView>
 
 @code{
+    SfPivotView<ProductDetails> pivot;
     public List<ProductDetails> data { get; set; }
     protected override void OnInitialized()
     {


### PR DESCRIPTION
**Description**

The code snippets in the Blazor UG documentation's "Save and Load Pivot Layout" section are incorrect. The "pivot" declaration is missing from that section. To use the component instance, specify "SfPivotView<ProductDetails> pivot". So, we need to update the code example in the Blazor UG documentation section.

**Task link** : https://dev.azure.com/EssentialStudio/Ej2-Web/_workitems/edit/883058