### PR TITLE
docs(893176): otp images and placeholder value updated 

### DIFF
--- a/blazor/otp-input/input-types.md
+++ b/blazor/otp-input/input-types.md
@@ -53,7 +53,7 @@ You can set the [Type](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.I
 
 ```
 
-![Blazor OTP Input Component with Password Type](images/blazor-otp-text.png)
+![Blazor OTP Input Component with Password Type](images/blazor-otp-password.png)
 
 ## Value
 

--- a/blazor/otp-input/placeholder.md
+++ b/blazor/otp-input/placeholder.md
@@ -29,7 +29,7 @@ When a placeholder with multiple placeholder characters is provided each input f
 
 @using Syncfusion.Blazor.Inputs
 
-<SfOtpInput Placeholder="x"></SfOtpInput>
+<SfOtpInput Placeholder="wxyz"></SfOtpInput>
 
 ```
 

--- a/blazor/otp-input/styling-modes.md
+++ b/blazor/otp-input/styling-modes.md
@@ -51,4 +51,4 @@ You can use the underline style by setting the [StylingMode](https://help.syncfu
 
 ```
 
-![Blazor OTP Input Component with Underlined Mode](images/blazor-otp-filled.png)
+![Blazor OTP Input Component with Underlined Mode](images/blazor-otp-underlined.png)


### PR DESCRIPTION
### Description

Need to update otp images and placeholder value

### Screenshot
![image](https://github.com/syncfusion-content/blazor-docs/assets/119287329/6b90a4f3-8f79-4b02-9fc4-d33118aa19b0)
![image](https://github.com/syncfusion-content/blazor-docs/assets/119287329/0e4c62eb-1e9c-4b66-ab71-8f8b865d079a)

### Areas affected and ensured

None

### Test cases

NA

### Test bed sample location

NA

### Additional checklist

* Did you run the automation against your implementation? NA
* Is there any API name change? NA.
* Is there any existing behavior change of other features due to this code change? No
* Does your new code introduce new warnings or binding errors? No
* Does your code pass all FxCop and StyleCop rules? No
* Did you record this case in the unit test or UI test? No
