### PR TITLE
895522: We need to resolve the liquid exception in the toolbar.md file of the Blazor Docs repository.

### DIFF
--- a/blazor/rich-text-editor/toolbar.md
+++ b/blazor/rich-text-editor/toolbar.md
@@ -233,6 +233,9 @@ private List<ToolbarItemModel> textQuickToolbarItems = new List<ToolbarItemModel
 Refer the following link for more items in the text quick toolbar.
 https://blazor.syncfusion.com/documentation/rich-text-editor/tools/built-in-tools
 
+{% tabs %}
+{% highlight razor %}
+
 <SfRichTextEditor>
     <RichTextEditorQuickToolbarSettings Text="@TextQuickToolbarItems"></RichTextEditorQuickToolbarSettings>
     <p>The Rich Text Editor component is WYSIWYG ('what you see is what you get') editor that provides the best user experience to create and update the content. Users can format their content using standard toolbar commands.</p>


### PR DESCRIPTION
### Bug description
Need to validate and resolve the liquid exception in the toolbar.md file of the Blazor Docs repository.

### Root Cause / Analysis

I have checked the reported issue, and the issue occurred because the code highlight is not specified correctly. It hasn't added the code highlight start.
`{% tabs %}
{% highlight razor %}`

### Reason for not identifying earlier

This particular use case has not been tested previously.

### Is Breaking issue.?

No

### Is reported by customer in incident/forum.?
No

### Solution Description

I have corrected the code highlight.

### Areas affected and ensured

No

### E2E report details against this fix

No

### Did you included unit test cases.?

No

### Is there any API name changes.?

No

/label ~bug
/assign @ScrumMaster
/cc @ProductOwner