### PR TITLE
907597: Fix the null exception for the multiselect.

### DIFF
--- a/blazor/datagrid/cell-edit-types.md
+++ b/blazor/datagrid/cell-edit-types.md
@@ -744,7 +744,14 @@ You can able to render SfMultiSelect component in EditTemplate. In the below sam
             <Template>
                 @{
                     var d = (context as Order).ChosenItems;
-                    <span>@String.Join(",", d)</span>
+                    if (d != null)
+                    {
+                        <span>@String.Join(",", d)</span>
+                    }
+                    else
+                    {
+                        <span>@String.Empty</span>
+                    }
                 }
             </Template>
         </GridColumn>

--- a/blazor/datagrid/filtering.md
+++ b/blazor/datagrid/filtering.md
@@ -489,7 +489,7 @@ The **WildCard** filter can process one or more search patterns using the “*�
 * The **WildCard** filter option is supported for the DataGrid that has all search options.
 
 Operator |Description
------|-----|
+-----|-----
 a*b | Everything that starts with “a” and ends with “b”.
 a* | Everything that starts with “a”.
 *b | Everything that ends with “b”.


### PR DESCRIPTION
Documentation added for the task
BLAZ-907597 : Exception throws while save the record in multiselect edit template.
Task Link: https://dev.azure.com/EssentialStudio/Ej2-Web/_workitems/edit/907597/