### PR TITLE
Update toolbar-customization.md

### DIFF
--- a/blazor/pdfviewer-2/toolbar-customization.md
+++ b/blazor/pdfviewer-2/toolbar-customization.md
@@ -253,45 +253,47 @@ To customize the Primary Toolbar in the PDF Viewer, you can achieve this by sett
     // Get the renderfragment element for the custom toolbaritems in the primary toolbar
     private static RenderFragment GetTemplate(string name)  
     {  
-        return __builder => 
-            {  
-                if (name == "PreviousPage")
-                { 
-                    <ToolbarItem PrefixIcon="e-icons e-chevron-up" 
-                          		Text="Previous Page" 
-                                TooltipText="Previous Page" 
-                                Id="previousPage" 
-                                Align="ItemAlign.Left"> 
-                    </ToolbarItem> 
-                }  
-                else if(name == "NextPage")
-                { 
-                    <ToolbarItem PrefixIcon="e-icons e-chevron-down" 
-                                Text="Next Page" 
-                                TooltipText="Next Page" 
-                                Id="nextPage" 
-                                Align="ItemAlign.Left"> 
-                    </ToolbarItem> 
-                }  
-                else if(name == "Save")
-                { 
-                    <ToolbarItem PrefixIcon="e-icons e-save" 
-                                Text="Save" 
-                                TooltipText="Save Document" 
-                                Id="save" 
-                                Align="ItemAlign.Right"> 
-                    </ToolbarItem>
-                }  
-                else if(name == "Download")
-                { 
-                    <ToolbarItem PrefixIcon="e-icons e-download" 
-                                Text="Download"
-                                TooltipText="Download" 
-                                Id="download" 
-                                Align="ItemAlign.Right"> 
-                    </ToolbarItem> 
-                }  
-            };            
+        if (name == "PreviousPage")
+        {
+            return @<ToolbarItem PrefixIcon="e-icons e-chevron-up"
+                                 Text="Previous Page"
+                                 TooltipText="Previous Page"
+                                 Id="previousPage"
+                                 Align="ItemAlign.Left">
+            </ToolbarItem>;
+        }
+
+        if (name == "NextPage")
+        {
+            return @<ToolbarItem PrefixIcon="e-icons e-chevron-down"
+                                 Text="Next Page"
+                                 TooltipText="Next Page"
+                                 Id="nextPage"
+                                 Align="ItemAlign.Left">
+            </ToolbarItem>;
+        }
+
+        if (name == "Save")
+        {
+            return @<ToolbarItem PrefixIcon="e-icons e-save"
+                                 Text="Save"
+                                 TooltipText="Save Document"
+                                 Id="save"
+                                 Align="ItemAlign.Right">
+            </ToolbarItem>;
+        }
+
+        if (name == "Download")
+        {
+            return @<ToolbarItem PrefixIcon="e-icons e-download"
+                                 Text="Download"
+                                 TooltipText="Download"
+                                 Id="download"
+                                 Align="ItemAlign.Right">
+            </ToolbarItem>;
+        }
+
+        return _ => { };         
     }  
 
     // Click for the custom toolbaritems in the primary toolbar


### PR DESCRIPTION
The use of __builder is from an outdated version of Blazor.  Blazor now uses templated delegates.