### PR TITLE
904096: Need to correct the update value documentation section

### DIFF
--- a/blazor-toc.html
+++ b/blazor-toc.html
@@ -4059,6 +4059,7 @@
 				<ul>
 					<li> <a href="/blazor/rich-text-editor/how-to/blazor-web-assembly">Getting Started with Blazor WebAssembly RichTextEditor using Visual Studio</a></li>
 					<li> <a href="/blazor/rich-text-editor/how-to/rte-inside-dialog">RichTextEditor inside the Dialog component</a></li>
+					<li> <a href="/blazor/rich-text-editor/how-to/update-value">Capture ctrl+s to update the value</a></li>
 				</ul>
 			</li>
 			<li>

--- a/blazor/rich-text-editor/how-to/update-value.md
+++ b/blazor/rich-text-editor/how-to/update-value.md
@@ -14,40 +14,78 @@ To achieve this, the `keydown` event has to be bound to the Rich Text Editor con
 ```cshtml
 
 @using Syncfusion.Blazor.RichTextEditor
+@inject IJSRuntime JSRuntime
 
-<div class="control-section">
-    <SfRichTextEditor ID="defalt_RTE" ref="rteObj" onkeydown="@onKeydown" >
-        <RichTextEditorToolbarSettings Items="@tools"></RichTextEditorToolbarSettings>
-        <p>The Rich Text Editor component is WYSIWYG ('what you see is what you get') editor that provides the best user experience to create and update the content. Users can format their content using standard toolbar commands.</p>
-        <p><b> Key features:</b></p>
-        <ul>
-            <li><p> Provides <b>IFRAME</b> and <b>DIV</b> modes </p></li>
-            <li><p> Capable of handling markdown editing.</p></li>
-            <li><p> Contains a modular library to load the necessary functionality on demand.</p></li>
-            <li><p> Provides a fully customizable toolbar.</p></li>
-            <li><p> Provides HTML view to edit the source directly for developers.</p></li>
-            <li><p> Supports third - party library integration.</p></li>
-            <li><p> Allows preview of modified content before saving it.</p></li>
-        </ul>
+
+<div class="control-section"> 
+    <SfRichTextEditor ID="defalt_RTE" ref="editor" onkeydown="@onKeydown" @bind-Value="@RteValue">
+        <RichTextEditorToolbarSettings Items="@Tools"></RichTextEditorToolbarSettings>
     </SfRichTextEditor>
 </div>
-
-@functions {
-    SfRichTextEditor rteObj;
-
-    public static object[] tools = new object[] {
-        "Bold", "Italic", "Underline", "StrikeThrough",
-        "FontName", "FontSize", "FontColor", "BackgroundColor",
-        "LowerCase", "UpperCase", "|",
-        "Formats", "Alignments", "OrderedList", "UnorderedList",
-        "Outdent", "Indent", "|", "CreateTable",
-        "CreateLink", "Image", "|", "ClearFormat", "Print",
-        "SourceCode", "FullScreen", "|", "Undo", "Redo"
+<script>
+    window.preventSaveAction = function () {
+        document.addEventListener("keydown", function (e) {
+            if (e.ctrlKey && e.key === 's') {
+                e.preventDefault();
+            }
+        });
     };
-    public void onKeydown(UIKeyboardEventArgs arg) {
-        if (arg.Key == "s" && arg.CtrlKey == true) {
-            this.rteObj.UpdateValue();
-            var value = this.rteObj.Value;
+</script>
+
+@code {
+    SfRichTextEditor editor;
+    public String RteValue { get; set; } = "<p>The Rich Text Editor component is WYSIWYG ('what you see is what you get') editor that provides the best user experience to create and update the content. Users can format their content using standard toolbar commands.</p><p><b>Key features:</b></p><ul><li><p>Provides <b>IFRAME</b> and <b>DIV</b> modes</p></li><li><p>Capable of handling markdown editing.</p></li><li><p>Contains a modular library to load the necessary functionality on demand.</p></li><li><p>Provides a fully customizable toolbar.</p></li><li><p>Provides HTML view to edit the source directly for developers.</p></li><li><p>Supports third-party library integration.</p></li><li><p>Allows preview of modified content before saving it.</p></li></ul>";
+
+    private List<ToolbarItemModel> Tools = new List<ToolbarItemModel>()
+    {
+        new ToolbarItemModel() { Command = ToolbarCommand.Undo },
+        new ToolbarItemModel() { Command = ToolbarCommand.Redo },
+        new ToolbarItemModel() { Command = ToolbarCommand.Separator },
+        new ToolbarItemModel() { Command = ToolbarCommand.Bold },
+        new ToolbarItemModel() { Command = ToolbarCommand.Italic },
+        new ToolbarItemModel() { Command = ToolbarCommand.Underline },
+        new ToolbarItemModel() { Command = ToolbarCommand.StrikeThrough },
+        new ToolbarItemModel() { Command = ToolbarCommand.SuperScript },
+        new ToolbarItemModel() { Command = ToolbarCommand.SubScript },
+        new ToolbarItemModel() { Command = ToolbarCommand.Separator },
+        new ToolbarItemModel() { Command = ToolbarCommand.FontName },
+        new ToolbarItemModel() { Command = ToolbarCommand.FontSize },
+        new ToolbarItemModel() { Command = ToolbarCommand.FontColor },
+        new ToolbarItemModel() { Command = ToolbarCommand.BackgroundColor },
+        new ToolbarItemModel() { Command = ToolbarCommand.Separator },
+        new ToolbarItemModel() { Command = ToolbarCommand.LowerCase },
+        new ToolbarItemModel() { Command = ToolbarCommand.UpperCase },
+        new ToolbarItemModel() { Command = ToolbarCommand.Separator },
+        new ToolbarItemModel() { Command = ToolbarCommand.Formats },
+        new ToolbarItemModel() { Command = ToolbarCommand.Alignments },
+        new ToolbarItemModel() { Command = ToolbarCommand.Separator },
+        new ToolbarItemModel() { Command = ToolbarCommand.OrderedList },
+        new ToolbarItemModel() { Command = ToolbarCommand.UnorderedList },
+        new ToolbarItemModel() { Command = ToolbarCommand.Separator },
+        new ToolbarItemModel() { Command = ToolbarCommand.Outdent },
+        new ToolbarItemModel() { Command = ToolbarCommand.Indent },
+        new ToolbarItemModel() { Command = ToolbarCommand.Separator },
+        new ToolbarItemModel() { Command = ToolbarCommand.CreateLink },
+        new ToolbarItemModel() { Command = ToolbarCommand.Image },
+        new ToolbarItemModel() { Command = ToolbarCommand.CreateTable },
+        new ToolbarItemModel() { Command = ToolbarCommand.Separator },
+        new ToolbarItemModel() { Command = ToolbarCommand.ClearFormat },
+        new ToolbarItemModel() { Command = ToolbarCommand.Print },
+        new ToolbarItemModel() { Command = ToolbarCommand.SourceCode },
+        new ToolbarItemModel() { Command = ToolbarCommand.FullScreen },
+    };
+    public void onKeydown(KeyboardEventArgs arg)
+    {
+        if (arg.Key == "s" && arg.CtrlKey == true)
+        {
+            this.RteValue = this.editor.Value;
+        }
+    }
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await JSRuntime.InvokeVoidAsync("preventSaveAction");
         }
     }
 }

--- a/blazor/rich-text-editor/how-to/update-value.md
+++ b/blazor/rich-text-editor/how-to/update-value.md
@@ -23,17 +23,22 @@ To achieve this, the `keydown` event has to be bound to the Rich Text Editor con
     </SfRichTextEditor>
 </div>
 <script>
-    window.preventSaveAction = function () {
-        document.addEventListener("keydown", function (e) {
-            if (e.ctrlKey && e.key === 's') {
-                e.preventDefault();
-            }
-        });
+    window.preventSaveAction = function (elementId) {
+        var contentEditableElement = document.getElementById(elementId);
+        if (contentEditableElement) {
+            contentEditableElement.addEventListener("keydown", function (e) {
+                if (e.ctrlKey && e.key === 's') {
+                    e.preventDefault();  // Prevent default Ctrl+S save behavior
+                }
+            });
+        } 
     };
 </script>
 
 @code {
     SfRichTextEditor editor;
+    private string contentEditableId = "defalt_RTE_rte-editable";
+
     public String RteValue { get; set; } = "<p>The Rich Text Editor component is WYSIWYG ('what you see is what you get') editor that provides the best user experience to create and update the content. Users can format their content using standard toolbar commands.</p><p><b>Key features:</b></p><ul><li><p>Provides <b>IFRAME</b> and <b>DIV</b> modes</p></li><li><p>Capable of handling markdown editing.</p></li><li><p>Contains a modular library to load the necessary functionality on demand.</p></li><li><p>Provides a fully customizable toolbar.</p></li><li><p>Provides HTML view to edit the source directly for developers.</p></li><li><p>Supports third-party library integration.</p></li><li><p>Allows preview of modified content before saving it.</p></li></ul>";
 
     private List<ToolbarItemModel> Tools = new List<ToolbarItemModel>()
@@ -85,7 +90,7 @@ To achieve this, the `keydown` event has to be bound to the Rich Text Editor con
     {
         if (firstRender)
         {
-            await JSRuntime.InvokeVoidAsync("preventSaveAction");
+            await JSRuntime.InvokeVoidAsync("preventSaveAction", contentEditableId);
         }
     }
 }

--- a/blazor/rich-text-editor/how-to/update-value.md
+++ b/blazor/rich-text-editor/how-to/update-value.md
@@ -18,7 +18,7 @@ To achieve this, the `keydown` event has to be bound to the Rich Text Editor con
 
 
 <div class="control-section"> 
-    <SfRichTextEditor ID="defalt_RTE" ref="editor" onkeydown="@onKeydown" @bind-Value="@RteValue">
+    <SfRichTextEditor ID="richTextEditor" ref="editor" onkeydown="@onKeydown" @bind-Value="@RteValue">
         <RichTextEditorToolbarSettings Items="@Tools"></RichTextEditorToolbarSettings>
     </SfRichTextEditor>
 </div>
@@ -37,7 +37,7 @@ To achieve this, the `keydown` event has to be bound to the Rich Text Editor con
 
 @code {
     SfRichTextEditor editor;
-    private string contentEditableId = "defalt_RTE_rte-editable";
+    private string contentEditableId = "richTextEditor_rte-editable";
 
     public String RteValue { get; set; } = "<p>The Rich Text Editor component is WYSIWYG ('what you see is what you get') editor that provides the best user experience to create and update the content. Users can format their content using standard toolbar commands.</p><p><b>Key features:</b></p><ul><li><p>Provides <b>IFRAME</b> and <b>DIV</b> modes</p></li><li><p>Capable of handling markdown editing.</p></li><li><p>Contains a modular library to load the necessary functionality on demand.</p></li><li><p>Provides a fully customizable toolbar.</p></li><li><p>Provides HTML view to edit the source directly for developers.</p></li><li><p>Supports third-party library integration.</p></li><li><p>Allows preview of modified content before saving it.</p></li></ul>";
 


### PR DESCRIPTION
### Bug description
Need to correct the update value documentation section

### Root Cause / Analysis
The issue occurs because in the key down method have the UIKeyboardEventArgs instead of KeyboardEventArgs 

### Reason for not identifying earlier

This particular use case has not been tested previously.

### Is Breaking issue.?

No

### Is reported by customer in incident/forum.?
No

### Solution Description
The issue is resolved by changing the UIKeyboardEventArgs as KeyboardEventArgs and changed the corrected code.

### Areas affected and ensured

No

### E2E report details against this fix

No

### Did you included unit test cases.?

NA

### Is there any API name changes.?

No

/label ~bug
/assign @ScrumMaster
/cc @ProductOwner