### PR TITLE
902827: Arrow down key is not working in cell edit template sample

### DIFF
--- a/blazor/gantt-chart/managing-tasks.md
+++ b/blazor/gantt-chart/managing-tasks.md
@@ -123,7 +123,7 @@ The following code example describes, how to define the Edit template for a part
                 @{
                     var task = (context as TaskData);
                 }
-                <SfDropDownList @ref="dropdown" Placeholder="Name" FloatLabelType="Syncfusion.Blazor.Inputs.FloatLabelType.Always" ID="TaskName" Value="task.TaskName" TItem="string" TValue="string" DataSource="@DropDownData">
+                <SfDropDownList @ref="dropdown" Placeholder="Name" FloatLabelType="Syncfusion.Blazor.Inputs.FloatLabelType.Always" ID="TaskName" @bind-Value="task.TaskName" TItem="string" TValue="string" DataSource="@DropDownData">
                 </SfDropDownList>
             </EditTemplate>
         </GanttColumn>


### PR DESCRIPTION
Bug description
When trying to edit the task name using the arrow down key in the cell edit template sample, it does not work.