### PR TITLE
914644: segment template sample modified

### DIFF
--- a/blazor/gantt-chart/data-binding.md
+++ b/blazor/gantt-chart/data-binding.md
@@ -225,6 +225,7 @@ ExpandoObject can be bound to Gantt by assigning to the `DataSource` property. G
 ```cshtml
 
 @using Syncfusion.Blazor.Gantt
+@using System.Dynamic
 
 <SfGantt TValue="ExpandoObject" DataSource="@TreeData" @ref="Gantt" Height="450px" Width="700px">
     <GanttTaskFields Id="TaskID" Name="TaskName" StartDate="StartDate" Duration="Duration"

--- a/blazor/gantt-chart/split-task.md
+++ b/blazor/gantt-chart/split-task.md
@@ -580,7 +580,9 @@ In the code snippet below, the segments are customized based on template context
     </GanttTaskFields>
     <GanttEditSettings AllowAdding="true" AllowDeleting="true" AllowEditing="true" AllowTaskbarEditing="true"></GanttEditSettings>
     <GanttSegmentFields PrimaryKey="Id" ForeignKey="TaskId" StartDate="SegmentStartDate" EndDate="SegmentEndDate" Duration="SegmentDuration" TValue="TaskData" TSegments="SegmentModel" DataSource="segmentCollection"></GanttSegmentFields>
-    <GanttLabelSettings LeftLabel="TaskName" TValue="TaskData"></GanttLabelSettings>
+    <GanttLabelSettings LeftLabel="TaskName" TValue="TaskData">
+
+    </GanttLabelSettings>
     <GanttColumns>
         <GanttColumn Field="TaskId" Width="100" Visible="false"></GanttColumn>
         <GanttColumn Field="TaskName" Width="250" ClipMode="Syncfusion.Blazor.Grids.ClipMode.EllipsisWithTooltip"></GanttColumn>
@@ -604,13 +606,18 @@ In the code snippet below, the segments are customized based on template context
                 {
                     foreach (var segment in segments)
                     {
+                        string textContent = "Segment " + (segment.SegmentIndex + 1);
                         <div class="e-gantt-child-taskbar-inner-div e-gantt-child-taskbar e-segmented-taskbar" style=@("height:24px;position: absolute;left:" + segment.Left + "px; width:" + segment.Width + "px;") tabindex=-1 data-segment-index="@(segment.SegmentIndex)">
                             <div class="e-taskbar-left-resizer e-icon" style="margin-top: 5px; left:2px">
                             </div>
                             <div class="e-gantt-child-progressbar-inner-div e-gantt-child-progressbar" style="height:24px;width:@(segment.ProgressWidth + "px");border-radius: 0px;text-align: right;">
+                                <div style=@("height:22px;position: absolute;line-height:21px;font-size: 11px;color: #fff;text-overflow:ellipsis;overflow-x:hidden;")>
+                                    <span>@textContent</span>
+                                </div>
                             </div>
                             <div class="e-taskbar-right-resizer e-icon" style="margin-top: 5px;left:@((segment.Width) - 15)px">
                             </div>
+
                         </div>
                     }
                 }

--- a/blazor/gantt-chart/split-task.md
+++ b/blazor/gantt-chart/split-task.md
@@ -580,9 +580,7 @@ In the code snippet below, the segments are customized based on template context
     </GanttTaskFields>
     <GanttEditSettings AllowAdding="true" AllowDeleting="true" AllowEditing="true" AllowTaskbarEditing="true"></GanttEditSettings>
     <GanttSegmentFields PrimaryKey="Id" ForeignKey="TaskId" StartDate="SegmentStartDate" EndDate="SegmentEndDate" Duration="SegmentDuration" TValue="TaskData" TSegments="SegmentModel" DataSource="segmentCollection"></GanttSegmentFields>
-    <GanttLabelSettings LeftLabel="TaskName" TValue="TaskData">
-
-    </GanttLabelSettings>
+    <GanttLabelSettings LeftLabel="TaskName" TValue="TaskData"></GanttLabelSettings>
     <GanttColumns>
         <GanttColumn Field="TaskId" Width="100" Visible="false"></GanttColumn>
         <GanttColumn Field="TaskName" Width="250" ClipMode="Syncfusion.Blazor.Grids.ClipMode.EllipsisWithTooltip"></GanttColumn>
@@ -617,7 +615,6 @@ In the code snippet below, the segments are customized based on template context
                             </div>
                             <div class="e-taskbar-right-resizer e-icon" style="margin-top: 5px;left:@((segment.Width) - 15)px">
                             </div>
-
                         </div>
                     }
                 }


### PR DESCRIPTION
### Description

The segment template and expando object section in the UG changes modified and updated.

### Screenshot

The previously attached code snippet did not include the label. We have now updated the code with the label and made the necessary changes.

Before code snippet O/P :

<img width="707" alt="label1" src="https://github.com/user-attachments/assets/f62d8e2d-41b7-4e35-8a18-881780233cdb">


After code snippet changed O/P:

<img width="656" alt="label2" src="https://github.com/user-attachments/assets/08fe0c1a-791b-4001-a595-a5274d270c60">


### Areas affected and ensured

None

### Test cases

NA

### Test bed sample location

NA

### Additional checklist

* Did you run the automation against your implementation? NA
* Is there any API name change? NA.
* Is there any existing behavior change of other features due to this code change? No
* Does your new code introduce new warnings or binding errors? No
* Does your code pass all FxCop and StyleCop rules? No
* Did you record this case in the unit test or UI test? No
