### PR TITLE
Documentation(69252) column validation

### DIFF
--- a/blazor/treegrid/editing/column-validation.md
+++ b/blazor/treegrid/editing/column-validation.md
@@ -133,7 +133,7 @@ Toolbar="@(new List<string>() { "Edit", "Update", "Cancel" })">
     {
         protected override ValidationResult IsValid(object value, ValidationContext validationContext)
         {
-            if (value != null)
+            if (value != null && value != "")
             {
                 int duration = (int)value;
                 if (duration >= 1 && duration <= 20)
@@ -155,7 +155,7 @@ Toolbar="@(new List<string>() { "Edit", "Update", "Cancel" })">
     {
         protected override ValidationResult IsValid(object value, ValidationContext validationContext)
         {
-            if (value != null)
+            if (value != null && value != "")
             {
                 string name = value.ToString();
                 if (name.Length >= 1 && name.Length <= 7)

--- a/blazor/treegrid/editing/column-validation.md
+++ b/blazor/treegrid/editing/column-validation.md
@@ -155,6 +155,7 @@ Toolbar="@(new List<string>() { "Edit", "Update", "Cancel" })">
     {
         protected override ValidationResult IsValid(object value, ValidationContext validationContext)
         {
+            // added condition check for empty string 
             if (value != null && value != "")
             {
                 string name = value.ToString();


### PR DESCRIPTION
Issue 1: 

Bug-Description :
   Alert popup is not working in Custom Validation Sample
   In the treegrid, when clearing the "Duration" field and saving, its saved with an empty value ,without showing any alert 
   message.

Root-Cause : 
    In the custom validation logic which is present in the sample side, the if condition checks if its is only null value or not and 
    then displays the alert message, which is wrong when entered with empty values.The expected alert message should be          
    like "No value", when saving an empty value.
   
Reason:
    Issue occurs in the custom validation logic ,where it doesn't validate whether the value is empty or not

Solution description : 
    In the if condition present in the custom validation logic ,added a condition which checks for empty values along with null 
    value. And hence displaying the proper alert message.



Issue 2: 

Bug-Description :
   Alert popup is not working in Custom Validation Sample
   In the treegrid, when clearing the "Priority" field and saving, its saved with an empty value with showing an wrong alert 
   message.

Root-Cause : 
    In the custom validation logic which is present in the sample side, the if condition checks if its is only null value or not and 
    then displays the alert message, which is wrong when entered with empty values. The expected alert message should be          
    like "No value", when saving an empty value.
   
Reason:
    Issue occurs in the custom validation logic ,where it doesn't validate whether the value is empty or not, as it only validates  
   the null values.

Solution description : 
    In the if condition present in the custom validation logic ,added a condition which checks for empty values along with null 
    value. And hence displaying the proper alert message.


