### PR TITLE
837836: Hyperlink not referred properly and alignment issue occurs in UG Blazor site

### DIFF
--- a/blazor/avatar/getting-started-with-web-app.md
+++ b/blazor/avatar/getting-started-with-web-app.md
@@ -9,7 +9,7 @@ documentation: ug
 
 # Getting Started with Blazor Avatar Component in Blazor Web App
 
-This section briefly explains about how to include [Blazor Avatar](https://blazor.syncfusion.com/documentation/avatar/getting-started) component in your Blazor Web App using [Visual Studio](https://visualstudio.microsoft.com/vs/).
+This section briefly explains about how to include [Blazor Avatar](https://blazor.syncfusion.com/demos/avatar/defaultfunctionalities?theme=fluent2) component in your Blazor Web App using [Visual Studio](https://visualstudio.microsoft.com/vs/).
 
 ## Prerequisites
 

--- a/blazor/avatar/getting-started.md
+++ b/blazor/avatar/getting-started.md
@@ -11,7 +11,7 @@ documentation: ug
 
 # Getting Started with Blazor Avatar Component
 
-This section briefly explains about how to include [Blazor Avatar](https://blazor.syncfusion.com/documentation/avatar/getting-started) component in your Blazor Server App and Blazor WebAssembly App using Visual Studio.
+This section briefly explains about how to include [Blazor Avatar](https://blazor.syncfusion.com/demos/avatar/defaultfunctionalities?theme=fluent2) component in your Blazor Server App and Blazor WebAssembly App using Visual Studio.
 
 To get start quickly with Avatar component using Blazor, you can check on this video:
 


### PR DESCRIPTION
### Bug description
https://syncfusion.sharepoint.com/sites/WebFileManager/_layouts/15/Doc.aspx?sourcedoc={19b9a9f4-ec28-4b0a-8199-06e8b65b6a92}&action=edit&wd=target%28Testing%2FTesting%202023%20Volume%202.one%7Cae657d68-84d1-4d05-8714-823e2b1e830f%2FBlazor%20-%20Documentation%20testing%7Ca6b40384-eedc-45fb-af8b-6807fc0d4f0d%2F%29&wdorigin=NavigationUrl

The issue mentioned in the above one-note page need to be resolve.

### Root cause
Link for the Avatar component is mapped but it opens the same page.

### Solution description
Some of the queries are resolved in live documentation. 
For the link in Avatar component is mapped as Avatar demo. 
For the space issue in ListView is corrected for UI puprpose.

### Reason for not identifying earlier
 * [] Guidelines not followed. If yes, provide which guideline is not followed.

 * [ ] Guidelines not given. If yes, provide which/who need to address.
    Tag label `update-guideline-coreteam` or `update-guideline-productteam`. 

 * [X] If any other reason, provide the details here. 
 Some of the queries were not noticed earlier.

### Output screenshots
N/A

### Reviewer Checklist
* []  All provided information are reviewed and ensured.