### PR TITLE
SEO-193073--Blazor-predefined-dialogs-draggable--Description-too-short

### DIFF
--- a/blazor/combobox/value-binding.md
+++ b/blazor/combobox/value-binding.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  Data Binding in Blazor ComboBox Component | Syncfusion
-description: Checkout and learn here all about value binding in Syncfusion Blazor ComboBox component and more.
+description: Learn here all about value binding in Syncfusion Blazor Combobox component of Syncfusion Essential JS 2 and more.
 platform: Blazor
 control: ComboBox
 documentation: ug

--- a/blazor/predefined-dialogs/draggable.md
+++ b/blazor/predefined-dialogs/draggable.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Draggable in the Predefined Dialogs in Blazor | Syncfusion
-description: Check out and learn here all about draggable in the predefined dialogs and much more details.
+description: Learn here all about Draggable in Syncfusion Blazor Predefined dialogs component of Syncfusion Essential JS 2 and more.
 platform: Blazor
 control: Predefined Dialogs
 documentation: ug

--- a/blazor/scheduler/appointment-drag-and-drop.md
+++ b/blazor/scheduler/appointment-drag-and-drop.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Drag and drop in Blazor Scheduler Component | Syncfusion
-description: Checkout and learn here all about recurring events in Syncfusion Blazor Scheduler component.
+description: Learn here all about appointment drag and drop in Syncfusion Blazor Schedule component of Syncfusion Essential JS 2 and more.
 platform: Blazor
 control: Scheduler
 documentation: ug

--- a/blazor/scheduler/appointment-drag-and-drop.md
+++ b/blazor/scheduler/appointment-drag-and-drop.md
@@ -7,7 +7,7 @@ control: Scheduler
 documentation: ug
 ---
 
-# Drag and drop
+# Drag and drop in Blazor Scheduler Component
 
 Appointments can be rescheduled to any time by dragging and dropping them onto the desired location. To work with drag and drop functionality make sure that [AllowDragAndDrop](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.Schedule.SfSchedule-1.html#Syncfusion_Blazor_Schedule_SfSchedule_1_AllowDragAndDrop) is set to **true** on Scheduler. In mobile mode, you can drag and drop the events by tap holding an event and dropping them on to the desired location.
 


### PR DESCRIPTION
Title | Description
-- | --
|Task Category | Site Audit Work- Description too long|
|Content Task Link/Mail Screenshot | ![image](https://github.com/user-attachments/assets/5ab4d7c9-94e6-494c-a388-b76da5aa5aaf)|
|Hotfix | https://github.com/syncfusion-content/blazor-docs/pull/5173|
|Ticket/Task link | https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/193073|
|Work link |https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/doc.aspx?sourcedoc=%7B8b9ba150-19c4-4939-b62f-60ba198b5167%7D&action=edit&wdOrigin=TEAMS-MAGLEV.p2p_ns.rwc&wdExp=TEAMS-TREATMENT&wdhostclicktime=1732793473334&web=1|

Changes Made | Reason for change |
|-- | -- |
|Worked on Description too long | In SEO the description should range from 100 to 170-character count| 
| Updated H1 title                             | To resolve ci issue |