### PR TITLE
926183: Trademark Symbol Inclusion for Essential Studio Term -dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Syncfusion® Blazor Documentation
+# Syncfusion&reg; Blazor Documentation
 
-This is the GitHub repository for the technical product documentation for Syncfusion® Blazor components. This documentation is published to https://blazor.syncfusion.com/documentation/introduction
+This is the GitHub repository for the technical product documentation for Syncfusion&reg; Blazor components. This documentation is published to https://blazor.syncfusion.com/documentation/introduction
 
 ## Contributions Welcome!
 

--- a/blazor/pdfviewer-2/accessibility.md
+++ b/blazor/pdfviewer-2/accessibility.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Keyboard accessibility in Blazor SfPdfViewer | Syncfusion&reg;
-description: Checkout and learn here all about Keyboard accessibility in Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Keyboard accessibility in Blazor SfPdfViewer Component | Syncfusion
+description: Checkout and learn here all about Keyboard accessibility in Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/accessibility.md
+++ b/blazor/pdfviewer-2/accessibility.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Keyboard accessibility in Blazor SfPdfViewer Component | Syncfusion&reg;
+title: Keyboard accessibility in Blazor SfPdfViewer | Syncfusion&reg;
 description: Checkout and learn here all about Keyboard accessibility in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer

--- a/blazor/pdfviewer-2/accessibility.md
+++ b/blazor/pdfviewer-2/accessibility.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Keyboard accessibility in Blazor SfPdfViewer Component | Syncfusion®
-description: Checkout and learn here all about Keyboard accessibility in Syncfusion® Blazor SfPdfViewer component and more.
+title: Keyboard accessibility in Blazor SfPdfViewer Component | Syncfusion&reg;
+description: Checkout and learn here all about Keyboard accessibility in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug
 ---
 
-# Accessibility in Syncfusion® Blazor SfPdfViewer components
+# Accessibility in Syncfusion&reg; Blazor SfPdfViewer components
 
 The Blazor SfPdfViewer component followed the accessibility guidelines and standards, including [ADA](https://www.ada.gov/), [Section 508](https://www.section508.gov/), [WCAG 2.2](https://www.w3.org/TR/WCAG22/) standards, and [WCAG roles](https://www.w3.org/TR/wai-aria/#roles) that are commonly used to evaluate accessibility.
 

--- a/blazor/pdfviewer-2/annotation/annotations-in-mobile-view.md
+++ b/blazor/pdfviewer-2/annotation/annotations-in-mobile-view.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Annotations in Mobile View using SfPdfViewer | Syncfusion&reg;
-description: Checkout and learn everything about annotations in the mobile view using the Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Annotations in Mobile View using SfPdfViewer Component | Syncfusion
+description: Checkout and learn everything about annotations in the mobile view using the Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/annotation/annotations-in-mobile-view.md
+++ b/blazor/pdfviewer-2/annotation/annotations-in-mobile-view.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Annotations in Mobile View using SfPdfViewer Component | Syncfusion&reg;
+title: Annotations in Mobile View using SfPdfViewer | Syncfusion&reg;
 description: Checkout and learn everything about annotations in the mobile view using the Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer

--- a/blazor/pdfviewer-2/annotation/annotations-in-mobile-view.md
+++ b/blazor/pdfviewer-2/annotation/annotations-in-mobile-view.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Annotations in Mobile View using SfPdfViewer Component | Syncfusion®
-description: Checkout and learn everything about annotations in the mobile view using the Syncfusion® Blazor SfPdfViewer component and more.
+title: Annotations in Mobile View using SfPdfViewer Component | Syncfusion&reg;
+description: Checkout and learn everything about annotations in the mobile view using the Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/annotation/comments.md
+++ b/blazor/pdfviewer-2/annotation/comments.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Comments in Blazor SfPdfViewer Component | Syncfusion&reg;
-description: Checkout and learn here all about comments in Syncfusion&reg; Blazor SfPdfViewer component and much more details.
+title: Comments in Blazor SfPdfViewer Component | Syncfusion
+description: Checkout and learn here all about comments in Syncfusion Blazor SfPdfViewer component and much more details.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/annotation/comments.md
+++ b/blazor/pdfviewer-2/annotation/comments.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Comments in Blazor SfPdfViewer Component | Syncfusion®
-description: Checkout and learn here all about comments in Syncfusion® Blazor SfPdfViewer component and much more details.
+title: Comments in Blazor SfPdfViewer Component | Syncfusion&reg;
+description: Checkout and learn here all about comments in Syncfusion&reg; Blazor SfPdfViewer component and much more details.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/annotation/free-text-annotation.md
+++ b/blazor/pdfviewer-2/annotation/free-text-annotation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Free text annotations in Blazor SfPdfViewer Component | Syncfusion®
-description: Checkout and learn here all about free text annotations in Syncfusion® Blazor SfPdfViewer component and more.
+title: Free text annotations in Blazor SfPdfViewer Component | Syncfusion&reg;
+description: Checkout and learn here all about free text annotations in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/annotation/free-text-annotation.md
+++ b/blazor/pdfviewer-2/annotation/free-text-annotation.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Free text annotations in Blazor SfPdfViewer Component | Syncfusion&reg;
+title: Free text annotations in Blazor SfPdfViewer | Syncfusion&reg;
 description: Checkout and learn here all about free text annotations in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer

--- a/blazor/pdfviewer-2/annotation/free-text-annotation.md
+++ b/blazor/pdfviewer-2/annotation/free-text-annotation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Free text annotations in Blazor SfPdfViewer | Syncfusion&reg;
-description: Checkout and learn here all about free text annotations in Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Free text annotations in Blazor SfPdfViewer Component | Syncfusion
+description: Checkout and learn here all about free text annotations in Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/annotation/import-export-annotation.md
+++ b/blazor/pdfviewer-2/annotation/import-export-annotation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Import and Export annotations in Blazor SfPdfViewer | Syncfusion&reg;
-description: Learn here all about import and export annotations in Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Import and Export annotations in Blazor SfPdfViewer | Syncfusion
+description: Learn here all about import and export annotations in Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/annotation/import-export-annotation.md
+++ b/blazor/pdfviewer-2/annotation/import-export-annotation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Import and Export annotations in Blazor SfPdfViewer | Syncfusion®
-description: Learn here all about import and export annotations in Syncfusion® Blazor SfPdfViewer component and more.
+title: Import and Export annotations in Blazor SfPdfViewer | Syncfusion&reg;
+description: Learn here all about import and export annotations in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/annotation/ink-annotation.md
+++ b/blazor/pdfviewer-2/annotation/ink-annotation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Ink Annotation in Blazor SfPdfViewer Component | Syncfusion&reg;
-description: Checkout and learn here all about free Ink annotations in Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Ink Annotation in Blazor SfPdfViewer Component | Syncfusion
+description: Checkout and learn here all about free Ink annotations in Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/annotation/ink-annotation.md
+++ b/blazor/pdfviewer-2/annotation/ink-annotation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Ink Annotation in Blazor SfPdfViewer Component | Syncfusion®
-description: Checkout and learn here all about free Ink annotations in Syncfusion® Blazor SfPdfViewer component and more.
+title: Ink Annotation in Blazor SfPdfViewer Component | Syncfusion&reg;
+description: Checkout and learn here all about free Ink annotations in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/annotation/measurement-annotation.md
+++ b/blazor/pdfviewer-2/annotation/measurement-annotation.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Measurement annotations in Blazor SfPdfViewer Component | Syncfusion&reg;
+title: Measurement annotations in Blazor SfPdfViewer | Syncfusion&reg;
 description: Checkout and learn here all about measurement annotations in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer

--- a/blazor/pdfviewer-2/annotation/measurement-annotation.md
+++ b/blazor/pdfviewer-2/annotation/measurement-annotation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Measurement annotations in Blazor SfPdfViewer Component | Syncfusion®
-description: Checkout and learn here all about measurement annotations in Syncfusion® Blazor SfPdfViewer component and more.
+title: Measurement annotations in Blazor SfPdfViewer Component | Syncfusion&reg;
+description: Checkout and learn here all about measurement annotations in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/annotation/measurement-annotation.md
+++ b/blazor/pdfviewer-2/annotation/measurement-annotation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Measurement annotations in Blazor SfPdfViewer | Syncfusion&reg;
-description: Checkout and learn here all about measurement annotations in Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Measurement annotations in Blazor SfPdfViewer Component | Syncfusion
+description: Checkout and learn here all about measurement annotations in Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/annotation/shape-annotation.md
+++ b/blazor/pdfviewer-2/annotation/shape-annotation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Shape annotations in Blazor SfPdfViewer Component | Syncfusion&reg;
-description: Checkout and learn here all about shape annotations in Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Shape annotations in Blazor SfPdfViewer Component | Syncfusion
+description: Checkout and learn here all about shape annotations in Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/annotation/shape-annotation.md
+++ b/blazor/pdfviewer-2/annotation/shape-annotation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Shape annotations in Blazor SfPdfViewer Component | Syncfusion®
-description: Checkout and learn here all about shape annotations in Syncfusion® Blazor SfPdfViewer component and more.
+title: Shape annotations in Blazor SfPdfViewer Component | Syncfusion&reg;
+description: Checkout and learn here all about shape annotations in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/annotation/stamp-annotation.md
+++ b/blazor/pdfviewer-2/annotation/stamp-annotation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Stamp annotations in Blazor SfPdfViewer | Syncfusion&reg;
-description: Checkout and learn here all about stamp annotations in Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Stamp annotations in Blazor SfPdfViewer Component | Syncfusion
+description: Checkout and learn here all about stamp annotations in Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/annotation/stamp-annotation.md
+++ b/blazor/pdfviewer-2/annotation/stamp-annotation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Stamp annotations in Blazor SfPdfViewer Component | Syncfusion®
-description: Checkout and learn here all about stamp annotations in Syncfusion® Blazor SfPdfViewer component and more.
+title: Stamp annotations in Blazor SfPdfViewer Component | Syncfusion&reg;
+description: Checkout and learn here all about stamp annotations in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/annotation/stamp-annotation.md
+++ b/blazor/pdfviewer-2/annotation/stamp-annotation.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Stamp annotations in Blazor SfPdfViewer Component | Syncfusion&reg;
+title: Stamp annotations in Blazor SfPdfViewer | Syncfusion&reg;
 description: Checkout and learn here all about stamp annotations in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer

--- a/blazor/pdfviewer-2/annotation/sticky-notes-annotation.md
+++ b/blazor/pdfviewer-2/annotation/sticky-notes-annotation.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Sticky notes annotations in Blazor SfPdfViewer Component | Syncfusion&reg;
+title: Sticky notes annotations in Blazor SfPdfViewer | Syncfusion&reg;
 description: Checkout and learn here all about sticky notes annotations in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer

--- a/blazor/pdfviewer-2/annotation/sticky-notes-annotation.md
+++ b/blazor/pdfviewer-2/annotation/sticky-notes-annotation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Sticky notes annotations in Blazor SfPdfViewer | Syncfusion&reg;
-description: Checkout and learn here all about sticky notes annotations in Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Sticky notes annotations in Blazor SfPdfViewer Component | Syncfusion
+description: Checkout and learn here all about sticky notes annotations in Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/annotation/sticky-notes-annotation.md
+++ b/blazor/pdfviewer-2/annotation/sticky-notes-annotation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Sticky notes annotations in Blazor SfPdfViewer Component | Syncfusion®
-description: Checkout and learn here all about sticky notes annotations in Syncfusion® Blazor SfPdfViewer component and more.
+title: Sticky notes annotations in Blazor SfPdfViewer Component | Syncfusion&reg;
+description: Checkout and learn here all about sticky notes annotations in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/annotation/text-markup-annotation.md
+++ b/blazor/pdfviewer-2/annotation/text-markup-annotation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Text markup annotations in Blazor SfPdfViewer | Syncfusion&reg;
-description: Checkout and learn here all about text markup annotations in Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Text markup annotations in Blazor SfPdfViewer Component | Syncfusion
+description: Checkout and learn here all about text markup annotations in Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/annotation/text-markup-annotation.md
+++ b/blazor/pdfviewer-2/annotation/text-markup-annotation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Text markup annotations in Blazor SfPdfViewer Component | Syncfusion®
-description: Checkout and learn here all about text markup annotations in Syncfusion® Blazor SfPdfViewer component and more.
+title: Text markup annotations in Blazor SfPdfViewer Component | Syncfusion&reg;
+description: Checkout and learn here all about text markup annotations in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug
@@ -338,7 +338,7 @@ Below is an example demonstrating how you can utilize this method to delete an a
 }
 
 ```
-This code snippet demonstrates how to programmatically delete an annotation within the Syncfusion® Blazor SfPdfViewer using the [DeleteAnnotationAsync](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerBase.html#Syncfusion_Blazor_SfPdfViewer_PdfViewerBase_DeleteAnnotationAsync_Syncfusion_Blazor_SfPdfViewer_PdfAnnotation_) method.
+This code snippet demonstrates how to programmatically delete an annotation within the Syncfusion&reg; Blazor SfPdfViewer using the [DeleteAnnotationAsync](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerBase.html#Syncfusion_Blazor_SfPdfViewer_PdfViewerBase_DeleteAnnotationAsync_Syncfusion_Blazor_SfPdfViewer_PdfAnnotation_) method.
 
 N> Alternatively, delete the annotation with the annotation ID using the [DeleteAnnotationAsync](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerBase.html#Syncfusion_Blazor_SfPdfViewer_PdfViewerBase_DeleteAnnotationAsync_System_String_) method.
 

--- a/blazor/pdfviewer-2/annotation/text-markup-annotation.md
+++ b/blazor/pdfviewer-2/annotation/text-markup-annotation.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Text markup annotations in Blazor SfPdfViewer Component | Syncfusion&reg;
+title: Text markup annotations in Blazor SfPdfViewer | Syncfusion&reg;
 description: Checkout and learn here all about text markup annotations in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer

--- a/blazor/pdfviewer-2/command-manager.md
+++ b/blazor/pdfviewer-2/command-manager.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Command Manager in Blazor SfPdfViewer Component | Syncfusion&reg;
-description: Checkout and learn here all about Command Manager in Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Command Manager in Blazor SfPdfViewer Component | Syncfusion
+description: Checkout and learn here all about Command Manager in Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/command-manager.md
+++ b/blazor/pdfviewer-2/command-manager.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Command Manager in Blazor SfPdfViewer Component | Syncfusion®
-description: Checkout and learn here all about Command Manager in Syncfusion® Blazor SfPdfViewer component and more.
+title: Command Manager in Blazor SfPdfViewer Component | Syncfusion&reg;
+description: Checkout and learn here all about Command Manager in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/deployment/aws-beanstalk-deployment.md
+++ b/blazor/pdfviewer-2/deployment/aws-beanstalk-deployment.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Blazor SfPdfViewer deployment in AWS BeanStalk | Syncfusion&reg;
+title: Blazor SfPdfViewer deployment in AWS BeanStalk | Syncfusion
 description: AWS Elastic Beanstalk simplifies the deployment and management of scalable web applications and services on Linux-based infrastructure
 platform: Blazor
 control: SfPdfViewer

--- a/blazor/pdfviewer-2/deployment/aws-beanstalk-deployment.md
+++ b/blazor/pdfviewer-2/deployment/aws-beanstalk-deployment.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Blazor SfPdfViewer deployment in AWS BeanStalk | Syncfusion®
+title: Blazor SfPdfViewer deployment in AWS BeanStalk | Syncfusion&reg;
 description: AWS Elastic Beanstalk simplifies the deployment and management of scalable web applications and services on Linux-based infrastructure
 platform: Blazor
 control: SfPdfViewer
@@ -9,7 +9,7 @@ documentation: ug
 
 # Deploy Blazor Server App on AWS Elastic Beanstalk Linux
 
-In this section, we'll guide you through the process of adding Syncfusion®'s Blazor PDF Viewer component to your Blazor Server app and deploy it on AWS Elastic Beanstalk. We'll break it down into simple steps to make it easy to follow. Additionally, you can find a fully functional example project on our [GitHub repository](https://github.com/SyncfusionExamples/blazor-pdf-viewer-examples/tree/master/Server%20Deployment/AWS/AWS_Elastic_Beanstalk/SfPdfViewerApp).
+In this section, we'll guide you through the process of adding Syncfusion&reg; Blazor PDF Viewer component to your Blazor Server app and deploy it on AWS Elastic Beanstalk. We'll break it down into simple steps to make it easy to follow. Additionally, you can find a fully functional example project on our [GitHub repository](https://github.com/SyncfusionExamples/blazor-pdf-viewer-examples/tree/master/Server%20Deployment/AWS/AWS_Elastic_Beanstalk/SfPdfViewerApp).
 
 ## Prerequisites
 
@@ -28,7 +28,7 @@ Add the following NuGet packages into the Blazor Server app.
 * [Syncfusion.Blazor.SfPdfViewer](https://www.nuget.org/packages/Syncfusion.Blazor.SfPdfViewer) 
 * [Syncfusion.Blazor.Themes](https://www.nuget.org/packages/Syncfusion.Blazor.Themes)
 
-## Register Syncfusion® Blazor Service
+## Register Syncfusion&reg; Blazor Service
 
 * In the **~/_Imports.razor** file, add the following namespaces:
 
@@ -41,7 +41,7 @@ Add the following NuGet packages into the Blazor Server app.
 {% endhighlight %}
 {% endtabs %}
 
-* Register the Syncfusion® Blazor Service in the **~/Program.cs** file.
+* Register the Syncfusion&reg; Blazor Service in the **~/Program.cs** file.
 
 {% tabs %}
 {% highlight c# tabtitle="~/Program.cs" hl_lines="3 9 12" %}
@@ -56,7 +56,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor().AddHubOptions(o => { o.MaximumReceiveMessageSize = 102400000; });
 
-// Add Syncfusion® Blazor service to the container.
+// Add Syncfusion&reg; Blazor service to the container.
 builder.Services.AddSyncfusionBlazor();
 
 var app = builder.Build();
@@ -72,9 +72,9 @@ Add the following stylesheet and script to the head section of the **~/Pages/_Ho
 {% highlight cshtml %}
 
 <head>
-    <!-- Syncfusion® Blazor PDF Viewer control's theme style sheet -->
+    <!-- Syncfusion&reg; Blazor PDF Viewer control's theme style sheet -->
     <link href="_content/Syncfusion.Blazor.Themes/bootstrap5.css" rel="stylesheet" />
-    <!-- Syncfusion® Blazor PDF Viewer control's scripts -->
+    <!-- Syncfusion&reg; Blazor PDF Viewer control's scripts -->
     <script src="_content/Syncfusion.Blazor.SfPdfViewer/scripts/syncfusion-blazor-sfpdfviewer.min.js" type="text/javascript"></script>
 </head>
 
@@ -83,7 +83,7 @@ Add the following stylesheet and script to the head section of the **~/Pages/_Ho
 
 ## Adding Blazor PDF Viewer Component
 
-Add the Syncfusion® PDF Viewer component in the **~/Pages/Index.razor** file
+Add the Syncfusion&reg; PDF Viewer component in the **~/Pages/Index.razor** file
 
 {% tabs %}
 {% highlight razor %}
@@ -102,7 +102,7 @@ N> If you don't provide the `DocumentPath` property value, the PDF Viewer compon
 
 ## Run the application
 
-Run the application, and the PDF file will be displayed using Syncfusion®'s Blazor PDF Viewer component in your browser.
+Run the application, and the PDF file will be displayed using Syncfusion&reg; Blazor PDF Viewer component in your browser.
 
 {% previewsample "https://blazorplayground.syncfusion.com/embed/hZVzNWqXLSZpnuzc?appbar=false&editor=false&result=true&errorlist=false&theme=bootstrap5" backgroundimage "[Blazor SfPdfViewer Component](aws-benstalk-deployment-images/blazor-pdfviewer.png)" %}
 

--- a/blazor/pdfviewer-2/deployment/aws-beanstalk-deployment.md
+++ b/blazor/pdfviewer-2/deployment/aws-beanstalk-deployment.md
@@ -56,7 +56,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor().AddHubOptions(o => { o.MaximumReceiveMessageSize = 102400000; });
 
-// Add Syncfusion&reg; Blazor service to the container.
+// Add Syncfusion Blazor service to the container.
 builder.Services.AddSyncfusionBlazor();
 
 var app = builder.Build();
@@ -72,9 +72,9 @@ Add the following stylesheet and script to the head section of the **~/Pages/_Ho
 {% highlight cshtml %}
 
 <head>
-    <!-- Syncfusion&reg; Blazor PDF Viewer control's theme style sheet -->
+    <!-- Syncfusion Blazor PDF Viewer control's theme style sheet -->
     <link href="_content/Syncfusion.Blazor.Themes/bootstrap5.css" rel="stylesheet" />
-    <!-- Syncfusion&reg; Blazor PDF Viewer control's scripts -->
+    <!-- Syncfusion Blazor PDF Viewer control's scripts -->
     <script src="_content/Syncfusion.Blazor.SfPdfViewer/scripts/syncfusion-blazor-sfpdfviewer.min.js" type="text/javascript"></script>
 </head>
 

--- a/blazor/pdfviewer-2/events.md
+++ b/blazor/pdfviewer-2/events.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Events in Blazor SfPdfViewer Component | Syncfusion&reg;
-description: Checkout and learn here all about events in Syncfusion&reg; Blazor SfPdfViewer component and much more details.
+title: Events in Blazor SfPdfViewer Component | Syncfusion
+description: Checkout and learn here all about events in Syncfusion Blazor SfPdfViewer component and much more details.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/events.md
+++ b/blazor/pdfviewer-2/events.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Events in Blazor SfPdfViewer Component | Syncfusion®
-description: Checkout and learn here all about events in Syncfusion® Blazor SfPdfViewer component and much more details.
+title: Events in Blazor SfPdfViewer Component | Syncfusion&reg;
+description: Checkout and learn here all about events in Syncfusion&reg; Blazor SfPdfViewer component and much more details.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug
@@ -61,7 +61,7 @@ The events provided in SfPdfViewer component are listed out as follows:
 
 ## Adding SfPdfViewer events to Blazor component
 
-The Syncfusion® SfPdfViewer events has to be wrapped inside the [PdfViewerEvents](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerEvents.html) tag.
+The Syncfusion&reg; SfPdfViewer events has to be wrapped inside the [PdfViewerEvents](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerEvents.html) tag.
 
 ```cshtml
 

--- a/blazor/pdfviewer-2/form-filling.md
+++ b/blazor/pdfviewer-2/form-filling.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Form filling in Blazor SfPdfViewer Component | Syncfusion&reg;
-description: Checkout and learn here all about form filling in Syncfusion&reg; Blazor SfPdfViewer component and much more.
+title: Form filling in Blazor SfPdfViewer Component | Syncfusion
+description: Checkout and learn here all about form filling in Syncfusion Blazor SfPdfViewer component and much more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/form-filling.md
+++ b/blazor/pdfviewer-2/form-filling.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Form filling in Blazor SfPdfViewer Component | Syncfusion®
-description: Checkout and learn here all about form filling in Syncfusion® Blazor SfPdfViewer component and much more.
+title: Form filling in Blazor SfPdfViewer Component | Syncfusion&reg;
+description: Checkout and learn here all about form filling in Syncfusion&reg; Blazor SfPdfViewer component and much more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/getting-started/deploy-maui-windows.md
+++ b/blazor/pdfviewer-2/getting-started/deploy-maui-windows.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Deploy SfPdfViewer in Blazor MAUI in windows | Syncfusion®
-description: Learn how to deploy SfPdfViewer in Blazor MAUI Application on Windows in Syncfusion® Blazor SfPdfViewer component and much more details.
+title: Deploy SfPdfViewer in Blazor MAUI in windows | Syncfusion&reg;
+description: Learn how to deploy SfPdfViewer in Blazor MAUI Application on Windows in Syncfusion&reg; Blazor SfPdfViewer component and much more details.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug
@@ -9,7 +9,7 @@ documentation: ug
 
 # View PDF files using PDF Viewer Component in the Blazor MAUI app 
 
-In this section, we'll guide you through the process of adding Syncfusion®'s Blazor PDF Viewer component to your Blazor Maui app. We'll break it down into simple steps to make it easy to follow.
+In this section, we'll guide you through the process of adding Syncfusion&reg; Blazor PDF Viewer component to your Blazor Maui app. We'll break it down into simple steps to make it easy to follow.
 
 ## Prerequisites
 
@@ -28,7 +28,7 @@ Add the following NuGet packages into the Blazor Maui app.
 * [Syncfusion.Blazor.SfPdfViewer](https://www.nuget.org/packages/Syncfusion.Blazor.SfPdfViewer) 
 * [Syncfusion.Blazor.Themes](https://www.nuget.org/packages/Syncfusion.Blazor.Themes)
 
-## Register Syncfusion® Blazor Service
+## Register Syncfusion&reg; Blazor Service
 
 * In the **~/_Imports.razor** file, add the following namespaces:
 
@@ -41,7 +41,7 @@ Add the following NuGet packages into the Blazor Maui app.
 {% endhighlight %}
 {% endtabs %}
 
-* Register the Syncfusion® Blazor Service in the **~/MauiProgram.cs** file.
+* Register the Syncfusion&reg; Blazor Service in the **~/MauiProgram.cs** file.
 
 {% tabs %}
 {% highlight c# tabtitle="~/MauiProgram.cs" hl_lines="3 20 28" %}
@@ -89,9 +89,9 @@ Add the following stylesheet and script to the head section of the **~/wwwroot/i
 {% highlight html %}
 
 <head>
-    <!-- Syncfusion® Blazor PDF Viewer control's theme style sheet -->
+    <!-- Syncfusion&reg; Blazor PDF Viewer control's theme style sheet -->
     <link href="_content/Syncfusion.Blazor.Themes/bootstrap5.css" rel="stylesheet" />
-    <!-- Syncfusion® Blazor PDF Viewer control's scripts -->
+    <!-- Syncfusion&reg; Blazor PDF Viewer control's scripts -->
     <script src="_content/Syncfusion.Blazor.SfPdfViewer/scripts/syncfusion-blazor-sfpdfviewer.min.js" type="text/javascript"></script>
 </head>
 
@@ -100,7 +100,7 @@ Add the following stylesheet and script to the head section of the **~/wwwroot/i
 
 ## Add PDF Viewer component
 
-Add the Syncfusion® PDF Viewer component in the **~/Pages/Index.razor** file.
+Add the Syncfusion&reg; PDF Viewer component in the **~/Pages/Index.razor** file.
 
 {% tabs %}
 {% highlight razor %}

--- a/blazor/pdfviewer-2/getting-started/deploy-maui-windows.md
+++ b/blazor/pdfviewer-2/getting-started/deploy-maui-windows.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Deploy SfPdfViewer in Blazor MAUI in windows | Syncfusion&reg;
-description: Learn how to deploy SfPdfViewer in Blazor MAUI Application on Windows in Syncfusion&reg; Blazor SfPdfViewer component and much more details.
+title: Deploy SfPdfViewer in Blazor MAUI in windows | Syncfusion
+description: Learn how to deploy SfPdfViewer in Blazor MAUI Application on Windows in Syncfusion Blazor SfPdfViewer component and much more details.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/getting-started/deploy-maui-windows.md
+++ b/blazor/pdfviewer-2/getting-started/deploy-maui-windows.md
@@ -89,9 +89,9 @@ Add the following stylesheet and script to the head section of the **~/wwwroot/i
 {% highlight html %}
 
 <head>
-    <!-- Syncfusion&reg; Blazor PDF Viewer control's theme style sheet -->
+    <!-- Syncfusion Blazor PDF Viewer control's theme style sheet -->
     <link href="_content/Syncfusion.Blazor.Themes/bootstrap5.css" rel="stylesheet" />
-    <!-- Syncfusion&reg; Blazor PDF Viewer control's scripts -->
+    <!-- Syncfusion Blazor PDF Viewer control's scripts -->
     <script src="_content/Syncfusion.Blazor.SfPdfViewer/scripts/syncfusion-blazor-sfpdfviewer.min.js" type="text/javascript"></script>
 </head>
 

--- a/blazor/pdfviewer-2/getting-started/features.md
+++ b/blazor/pdfviewer-2/getting-started/features.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Overview of Blazor SfPdfViewer Component | Syncfusion®
-description: Checkout and learn about overview of the Syncfusion® Blazor SfPdfViewer component and much more details.
+title: Overview of Blazor SfPdfViewer Component | Syncfusion&reg;
+description: Checkout and learn about overview of the Syncfusion&reg; Blazor SfPdfViewer component and much more details.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/getting-started/features.md
+++ b/blazor/pdfviewer-2/getting-started/features.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Overview of Blazor SfPdfViewer Component | Syncfusion&reg;
-description: Checkout and learn about overview of the Syncfusion&reg; Blazor SfPdfViewer component and much more details.
+title: Overview of Blazor SfPdfViewer Component | Syncfusion
+description: Checkout and learn about overview of the Syncfusion Blazor SfPdfViewer component and much more details.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/getting-started/server-side-application.md
+++ b/blazor/pdfviewer-2/getting-started/server-side-application.md
@@ -58,7 +58,7 @@ builder.Services.AddServerSideBlazor();
 
 builder.Services.AddSignalR(o => { o.MaximumReceiveMessageSize = 102400000; });
 
-// Add Syncfusion&reg; Blazor service to the container.
+// Add Syncfusion Blazor service to the container.
 builder.Services.AddSyncfusionBlazor();
 
 var app = builder.Build();
@@ -76,9 +76,9 @@ Add the following stylesheet and script to the head section of the **~/Pages/_Ho
 {% highlight cshtml %}
 
 <head>
-    <!-- Syncfusion&reg; Blazor PDF Viewer control's theme style sheet -->
+    <!-- Syncfusion Blazor PDF Viewer control's theme style sheet -->
     <link href="_content/Syncfusion.Blazor.Themes/bootstrap5.css" rel="stylesheet" />
-    <!-- Syncfusion&reg; Blazor PDF Viewer control's scripts -->
+    <!-- Syncfusion Blazor PDF Viewer control's scripts -->
     <script src="_content/Syncfusion.Blazor.SfPdfViewer/scripts/syncfusion-blazor-sfpdfviewer.min.js" type="text/javascript"></script>
 </head>
 

--- a/blazor/pdfviewer-2/getting-started/server-side-application.md
+++ b/blazor/pdfviewer-2/getting-started/server-side-application.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Getting Started with SfPdfViewer in Blazor Server App | Syncfusion&reg;
+title: Getting Started with SfPdfViewer Blazor Server App | Syncfusion&reg;
 description: Learn how to getting started with SfPdfViewer control in Blazor Server-side application. You can view and comment on PDFs in ease and also can fill fields. 
 platform: Blazor
 control: SfPdfViewer

--- a/blazor/pdfviewer-2/getting-started/server-side-application.md
+++ b/blazor/pdfviewer-2/getting-started/server-side-application.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Getting Started with SfPdfViewer in Blazor Server App | Syncfusion®
+title: Getting Started with SfPdfViewer in Blazor Server App | Syncfusion&reg;
 description: Learn how to getting started with SfPdfViewer control in Blazor Server-side application. You can view and comment on PDFs in ease and also can fill fields. 
 platform: Blazor
 control: SfPdfViewer
@@ -9,7 +9,7 @@ documentation: ug
 
 # View PDF files using PDF Viewer Component in the Blazor Server app
 
-In this section, we'll guide you through the process of adding Syncfusion®'s Blazor PDF Viewer component to your Blazor Server app. We'll break it down into simple steps to make it easy to follow. Additionally, you can find a fully functional example project on our [GitHub repository](https://github.com/SyncfusionExamples/Blazor-Getting-Started-Examples/tree/main/PDFViewer%20%202/BlazorServerApp/PDFViewerSample).
+In this section, we'll guide you through the process of adding Syncfusion&reg; Blazor PDF Viewer component to your Blazor Server app. We'll break it down into simple steps to make it easy to follow. Additionally, you can find a fully functional example project on our [GitHub repository](https://github.com/SyncfusionExamples/Blazor-Getting-Started-Examples/tree/main/PDFViewer%20%202/BlazorServerApp/PDFViewerSample).
 
 ## Prerequisites
 
@@ -28,7 +28,7 @@ Add the following NuGet packages into the Blazor Server app.
 * [Syncfusion.Blazor.SfPdfViewer](https://www.nuget.org/packages/Syncfusion.Blazor.SfPdfViewer) 
 * [Syncfusion.Blazor.Themes](https://www.nuget.org/packages/Syncfusion.Blazor.Themes)
 
-## Register Syncfusion® Blazor Service
+## Register Syncfusion&reg; Blazor Service
 
 * In the **~/_Imports.razor** file, add the following namespaces:
 
@@ -41,7 +41,7 @@ Add the following NuGet packages into the Blazor Server app.
 {% endhighlight %}
 {% endtabs %}
 
-* Register the Syncfusion® Blazor Service in the **~/Program.cs** file.
+* Register the Syncfusion&reg; Blazor Service in the **~/Program.cs** file.
 
 {% tabs %}
 {% highlight c# tabtitle="~/Program.cs" hl_lines="3 11 14" %}
@@ -58,7 +58,7 @@ builder.Services.AddServerSideBlazor();
 
 builder.Services.AddSignalR(o => { o.MaximumReceiveMessageSize = 102400000; });
 
-// Add Syncfusion® Blazor service to the container.
+// Add Syncfusion&reg; Blazor service to the container.
 builder.Services.AddSyncfusionBlazor();
 
 var app = builder.Build();
@@ -76,9 +76,9 @@ Add the following stylesheet and script to the head section of the **~/Pages/_Ho
 {% highlight cshtml %}
 
 <head>
-    <!-- Syncfusion® Blazor PDF Viewer control's theme style sheet -->
+    <!-- Syncfusion&reg; Blazor PDF Viewer control's theme style sheet -->
     <link href="_content/Syncfusion.Blazor.Themes/bootstrap5.css" rel="stylesheet" />
-    <!-- Syncfusion® Blazor PDF Viewer control's scripts -->
+    <!-- Syncfusion&reg; Blazor PDF Viewer control's scripts -->
     <script src="_content/Syncfusion.Blazor.SfPdfViewer/scripts/syncfusion-blazor-sfpdfviewer.min.js" type="text/javascript"></script>
 </head>
 
@@ -87,7 +87,7 @@ Add the following stylesheet and script to the head section of the **~/Pages/_Ho
 
 ## Adding Blazor PDF Viewer Component
 
-Add the Syncfusion® PDF Viewer component in the **~/Pages/Index.razor** file
+Add the Syncfusion&reg; PDF Viewer component in the **~/Pages/Index.razor** file
 
 {% tabs %}
 {% highlight razor %}
@@ -106,7 +106,7 @@ N> If you don't provide the [DocumentPath](https://help.syncfusion.com/cr/blazor
 
 ## Run the application
 
-Run the application, and the PDF file will be displayed using Syncfusion®'s Blazor PDF Viewer component in your browser.
+Run the application, and the PDF file will be displayed using Syncfusion&reg; Blazor PDF Viewer component in your browser.
 
 {% previewsample "https://blazorplayground.syncfusion.com/embed/hZVzNWqXLSZpnuzc?appbar=false&editor=false&result=true&errorlist=false&theme=bootstrap5" backgroundimage "[Blazor SfPdfViewer Component](gettingstarted-images/blazor-pdfviewer.png)" %}
 

--- a/blazor/pdfviewer-2/getting-started/server-side-application.md
+++ b/blazor/pdfviewer-2/getting-started/server-side-application.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Getting Started with SfPdfViewer Blazor Server App | Syncfusion
+title: Getting Started with SfPdfViewer in Blazor Server App | Syncfusion
 description: Learn how to getting started with SfPdfViewer control in Blazor Server-side application. You can view and comment on PDFs in ease and also can fill fields. 
 platform: Blazor
 control: SfPdfViewer

--- a/blazor/pdfviewer-2/getting-started/server-side-application.md
+++ b/blazor/pdfviewer-2/getting-started/server-side-application.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Getting Started with SfPdfViewer Blazor Server App | Syncfusion&reg;
+title: Getting Started with SfPdfViewer Blazor Server App | Syncfusion
 description: Learn how to getting started with SfPdfViewer control in Blazor Server-side application. You can view and comment on PDFs in ease and also can fill fields. 
 platform: Blazor
 control: SfPdfViewer

--- a/blazor/pdfviewer-2/getting-started/web-app.md
+++ b/blazor/pdfviewer-2/getting-started/web-app.md
@@ -9,7 +9,7 @@ documentation: ug
 
 # View PDF files using PDF Viewer Component in the Blazor Web app
 
-In this section, we’ll guide you through the process of adding Syncfusion&reg;’s Blazor PDF Viewer component to your Blazor web app using [Visual Studio](https://visualstudio.microsoft.com/vs/). We’ll break it down into simple steps to make it easy to follow.
+In this section, we’ll guide you through the process of adding Syncfusion&reg; Blazor PDF Viewer component to your Blazor web app using [Visual Studio](https://visualstudio.microsoft.com/vs/). We’ll break it down into simple steps to make it easy to follow.
 
 ## Prerequisites
 
@@ -90,7 +90,7 @@ builder.Services.AddRazorComponents()
 builder.Services.AddSignalR(o => { o.MaximumReceiveMessageSize = 102400000; });
 
 builder.Services.AddMemoryCache();
-//Add Syncfusion&reg; Blazor service to the container.
+//Add Syncfusion Blazor service to the container.
 builder.Services.AddSyncfusionBlazor();
 
 var app = builder.Build();
@@ -123,7 +123,7 @@ builder.Services.AddRazorComponents()
 .AddInteractiveWebAssemblyComponents();
 
 builder.Services.AddMemoryCache();
-//Add Syncfusion&reg; Blazor service to the container
+//Add Syncfusion Blazor service to the container
 builder.Services.AddSyncfusionBlazor();
 
 var app = builder.Build();
@@ -162,7 +162,7 @@ builder.Services.AddRazorComponents()
 builder.Services.AddSignalR(o => { o.MaximumReceiveMessageSize = 102400000; });
 
 builder.Services.AddMemoryCache();
-//Add Syncfusion&reg; Blazor service to the container
+//Add Syncfusion Blazor service to the container
 builder.Services.AddSyncfusionBlazor();
 
 var app = builder.Build();
@@ -193,9 +193,9 @@ Add the following stylesheet and script to the head section of the **~/Component
 
 ```html
 <head>
-    <!-- Syncfusion&reg; Blazor PDF Viewer control's theme style sheet -->
+    <!-- Syncfusion Blazor PDF Viewer control's theme style sheet -->
     <link href="_content/Syncfusion.Blazor.Themes/bootstrap5.css" rel="stylesheet" />
-    <!-- Syncfusion&reg; Blazor PDF Viewer control's scripts -->
+    <!-- Syncfusion Blazor PDF Viewer control's scripts -->
     <script src="_content/Syncfusion.Blazor.SfPdfViewer/scripts/syncfusion-blazor-sfpdfviewer.min.js" type="text/javascript"></script>
 </head>
 ```
@@ -233,7 +233,7 @@ N> If you don’t provide the [DocumentPath](https://help.syncfusion.com/cr/blaz
 
 ## Run the application
 
-Run the application, and the PDF file will be displayed using Syncfusion&reg;’s Blazor PDF Viewer component in your browser.
+Run the application, and the PDF file will be displayed using Syncfusion&reg; Blazor PDF Viewer component in your browser.
 
 {% previewsample "https://blazorplayground.syncfusion.com/embed/hZVzNWqXLSZpnuzc?appbar=false&editor=false&result=true&errorlist=false&theme=bootstrap5" backgroundimage "[Blazor SfPdfViewer Component](gettingstarted-images/blazor-pdfviewer.png)" %}
 

--- a/blazor/pdfviewer-2/getting-started/web-app.md
+++ b/blazor/pdfviewer-2/getting-started/web-app.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with SfPdfViewer in Blazor Web App | Syncfusion&reg;
-description: Learn how to getting started with SfPdfViewer&reg; control in Blazor Web App. You can view and comment on PDFs in ease and also can fill fields.
+title: Getting Started with SfPdfViewer in Blazor Web App | Syncfusion
+description: Learn how to getting started with SfPdfViewer control in Blazor Web App. You can view and comment on PDFs in ease and also can fill fields.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/getting-started/web-app.md
+++ b/blazor/pdfviewer-2/getting-started/web-app.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with SfPdfViewer in Blazor Web App | Syncfusion®
-description: Learn how to getting started with SfPdfViewer® control in Blazor Web App. You can view and comment on PDFs in ease and also can fill fields.
+title: Getting Started with SfPdfViewer in Blazor Web App | Syncfusion&reg;
+description: Learn how to getting started with SfPdfViewer&reg; control in Blazor Web App. You can view and comment on PDFs in ease and also can fill fields.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug
@@ -9,7 +9,7 @@ documentation: ug
 
 # View PDF files using PDF Viewer Component in the Blazor Web app
 
-In this section, we’ll guide you through the process of adding Syncfusion®’s Blazor PDF Viewer component to your Blazor web app using [Visual Studio](https://visualstudio.microsoft.com/vs/). We’ll break it down into simple steps to make it easy to follow.
+In this section, we’ll guide you through the process of adding Syncfusion&reg;’s Blazor PDF Viewer component to your Blazor web app using [Visual Studio](https://visualstudio.microsoft.com/vs/). We’ll break it down into simple steps to make it easy to follow.
 
 ## Prerequisites
 
@@ -33,7 +33,7 @@ To add **Blazor PDF Viewer** component in the app, open the NuGet package manage
 If you select an Interactive render mode as WebAssembly or Auto, you can install the NuGet package in the client-side project to add component in Web App.
 
 N> If you select an Interactive render mode as `WebAssembly or Auto`, you can install the NuGet package in the client-side project to add component in Web App.
-On the Syncfusion® side, we are using SkiaSharp.Views.Blazor version 2.88.8. Please make sure to reference this version as well.
+On the Syncfusion&reg; side, we are using SkiaSharp.Views.Blazor version 2.88.8. Please make sure to reference this version as well.
 * [SkiaSharp.Views.Blazor](https://www.nuget.org/packages/SkiaSharp.Views.Blazor)
 
 ![SkiaSharp Views Blazor](gettingstarted-images/skia-sharp-image.png)
@@ -59,7 +59,7 @@ Interactive render mode as WebAssembly or Auto, need to add the following proper
 
 The above configuration is required only for .NET 9 projects. Please ensure you use this setup for the corresponding version.
 
-## Register Syncfusion® Blazor Service
+## Register Syncfusion&reg; Blazor Service
 
 * In the **~/_Imports.razor** file, add the following namespaces:
 
@@ -72,9 +72,9 @@ The above configuration is required only for .NET 9 projects. Please ensure you 
 {% endhighlight %}
 {% endtabs %}
 
-* Register the Syncfusion® Blazor Service in the program.cs file of your Blazor Web App.
+* Register the Syncfusion&reg; Blazor Service in the program.cs file of your Blazor Web App.
 
-If you select an Interactive render mode as `WebAssembly` or `Auto`, you need to register the Syncfusion® Blazor service in both **~/Program.cs** files of your Blazor Web App.
+If you select an Interactive render mode as `WebAssembly` or `Auto`, you need to register the Syncfusion&reg; Blazor service in both **~/Program.cs** files of your Blazor Web App.
 
 {% tabs %}
 {% highlight c# tabtitle=".NET 9 & .NET 8 (~/Program.cs) Server" hl_lines="2 9 11 13" %}
@@ -90,7 +90,7 @@ builder.Services.AddRazorComponents()
 builder.Services.AddSignalR(o => { o.MaximumReceiveMessageSize = 102400000; });
 
 builder.Services.AddMemoryCache();
-//Add Syncfusion® Blazor service to the container.
+//Add Syncfusion&reg; Blazor service to the container.
 builder.Services.AddSyncfusionBlazor();
 
 var app = builder.Build();
@@ -123,7 +123,7 @@ builder.Services.AddRazorComponents()
 .AddInteractiveWebAssemblyComponents();
 
 builder.Services.AddMemoryCache();
-//Add Syncfusion® Blazor service to the container
+//Add Syncfusion&reg; Blazor service to the container
 builder.Services.AddSyncfusionBlazor();
 
 var app = builder.Build();
@@ -162,7 +162,7 @@ builder.Services.AddRazorComponents()
 builder.Services.AddSignalR(o => { o.MaximumReceiveMessageSize = 102400000; });
 
 builder.Services.AddMemoryCache();
-//Add Syncfusion® Blazor service to the container
+//Add Syncfusion&reg; Blazor service to the container
 builder.Services.AddSyncfusionBlazor();
 
 var app = builder.Build();
@@ -193,16 +193,16 @@ Add the following stylesheet and script to the head section of the **~/Component
 
 ```html
 <head>
-    <!-- Syncfusion® Blazor PDF Viewer control's theme style sheet -->
+    <!-- Syncfusion&reg; Blazor PDF Viewer control's theme style sheet -->
     <link href="_content/Syncfusion.Blazor.Themes/bootstrap5.css" rel="stylesheet" />
-    <!-- Syncfusion® Blazor PDF Viewer control's scripts -->
+    <!-- Syncfusion&reg; Blazor PDF Viewer control's scripts -->
     <script src="_content/Syncfusion.Blazor.SfPdfViewer/scripts/syncfusion-blazor-sfpdfviewer.min.js" type="text/javascript"></script>
 </head>
 ```
 
 ## Adding Blazor PDF Viewer Component
 
-Add the Syncfusion® PDF Viewer component in the **~Pages/.razor** file. If an interactivity location as `Per page/component` in the web app, define a render mode at the top of the **~Pages/.razor** component, as follows:
+Add the Syncfusion&reg; PDF Viewer component in the **~Pages/.razor** file. If an interactivity location as `Per page/component` in the web app, define a render mode at the top of the **~Pages/.razor** component, as follows:
 
 {% tabs %}
 {% highlight razor %}
@@ -215,7 +215,7 @@ Add the Syncfusion® PDF Viewer component in the **~Pages/.razor** file. If an i
 
 N> If an interactivity location as Global no need to mention render mode. Set the interactivity mode for whole sample.
 
-Add the Syncfusion® PDF Viewer component in the **~/Pages/Index.razor** file.
+Add the Syncfusion&reg; PDF Viewer component in the **~/Pages/Index.razor** file.
 
 {% tabs %}
 {% highlight razor %}
@@ -233,7 +233,7 @@ N> If you don’t provide the [DocumentPath](https://help.syncfusion.com/cr/blaz
 
 ## Run the application
 
-Run the application, and the PDF file will be displayed using Syncfusion®’s Blazor PDF Viewer component in your browser.
+Run the application, and the PDF file will be displayed using Syncfusion&reg;’s Blazor PDF Viewer component in your browser.
 
 {% previewsample "https://blazorplayground.syncfusion.com/embed/hZVzNWqXLSZpnuzc?appbar=false&editor=false&result=true&errorlist=false&theme=bootstrap5" backgroundimage "[Blazor SfPdfViewer Component](gettingstarted-images/blazor-pdfviewer.png)" %}
 

--- a/blazor/pdfviewer-2/getting-started/web-assembly-application.md
+++ b/blazor/pdfviewer-2/getting-started/web-assembly-application.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Getting Started with SfPdfViewer in Blazor WASM App | Syncfusion®
+title: Getting Started with SfPdfViewer in Blazor WASM App | Syncfusion&reg;
 description: Checkout and learn about getting started with Blazor SfPdfViewer component in Blazor WebAssembly (WASM) App using Visual Studio and more.
 platform: Blazor
 control: SfPdfViewer
@@ -9,7 +9,7 @@ documentation: ug
 
 # View PDF files using PDF Viewer Component in the Blazor WASM app
 
-In this section, we'll guide you through the process of adding Syncfusion®'s Blazor PDF Viewer component to your Blazor WebAssembly (WASM) app. We'll break it down into simple steps to make it easy to follow. Additionally, you can find a fully functional example project on our [GitHub repository](https://github.com/SyncfusionExamples/blazor-pdf-viewer-examples/tree/master/Getting%20Started/Client-side%20application).
+In this section, we'll guide you through the process of adding Syncfusion&reg; Blazor PDF Viewer component to your Blazor WebAssembly (WASM) app. We'll break it down into simple steps to make it easy to follow. Additionally, you can find a fully functional example project on our [GitHub repository](https://github.com/SyncfusionExamples/blazor-pdf-viewer-examples/tree/master/Getting%20Started/Client-side%20application).
 
 ## Prerequisites
 
@@ -33,7 +33,7 @@ Add the following NuGet packages into the Blazor WebAssembly app.
 * [Syncfusion.Blazor.Themes](https://www.nuget.org/packages/Syncfusion.Blazor.Themes)
 * [SkiaSharp.Views.Blazor](https://www.nuget.org/packages/SkiaSharp.Views.Blazor)
 
-N> On the Syncfusion® side, we are using SkiaSharp.Views.Blazor version 2.88.8. Please make sure to reference this version as well.
+N> On the Syncfusion&reg; side, we are using SkiaSharp.Views.Blazor version 2.88.8. Please make sure to reference this version as well.
 
 ## Add the following PropertyGroup and ItemGroup:
 
@@ -54,7 +54,7 @@ N> On the Syncfusion® side, we are using SkiaSharp.Views.Blazor version 2.88.8.
 
 The above configuration is required only for .NET 9 projects. Please ensure you use this setup for the corresponding version.
 
-## Register Syncfusion® Blazor Service
+## Register Syncfusion&reg; Blazor Service
 
 * In the **~/_Imports.razor** file, add the following namespaces:
 
@@ -67,7 +67,7 @@ The above configuration is required only for .NET 9 projects. Please ensure you 
 {% endhighlight %}
 {% endtabs %}
 
-* Register the Syncfusion® Blazor Service in the program.cs file.
+* Register the Syncfusion&reg; Blazor Service in the program.cs file.
 
 {% tabs %}
 {% highlight C# tabtitle=".NET 6 & .NET 7 (~/Program.cs)" hl_lines="3 9 13" %}
@@ -83,7 +83,7 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 builder.Services.AddMemoryCache();
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 
-// Add Syncfusion® Blazor service to the container.
+// Add Syncfusion&reg; Blazor service to the container.
 builder.Services.AddSyncfusionBlazor();
 await builder.Build().RunAsync();
 
@@ -98,9 +98,9 @@ Add the following stylesheet and script to the head section of the **wwwroot/ind
 {% highlight cshtml %}
 
 <head>
-    <!-- Syncfusion® Blazor PDF Viewer control's theme style sheet -->
+    <!-- Syncfusion&reg; Blazor PDF Viewer control's theme style sheet -->
     <link href="_content/Syncfusion.Blazor.Themes/bootstrap5.css" rel="stylesheet" />
-    <!-- Syncfusion® Blazor PDF Viewer control's scripts -->
+    <!-- Syncfusion&reg; Blazor PDF Viewer control's scripts -->
     <script src="_content/Syncfusion.Blazor.SfPdfViewer/scripts/syncfusion-blazor-sfpdfviewer.min.js" type="text/javascript"></script>
 </head>
 
@@ -109,7 +109,7 @@ Add the following stylesheet and script to the head section of the **wwwroot/ind
 
 ## Adding Blazor PDF Viewer Component
 
-Add the Syncfusion® PDF Viewer component in the **~/Pages/Index.razor** file.
+Add the Syncfusion&reg; PDF Viewer component in the **~/Pages/Index.razor** file.
 
 {% tabs %}
 {% highlight razor %}
@@ -128,7 +128,7 @@ N> If you don't provide the [DocumentPath](https://help.syncfusion.com/cr/blazor
 
 ## Run the application
 
-Run the application, and the PDF file will be displayed using Syncfusion®'s Blazor PDF Viewer component in your browser.
+Run the application, and the PDF file will be displayed using Syncfusion&reg; Blazor PDF Viewer component in your browser.
 
 {% previewsample "https://blazorplayground.syncfusion.com/embed/hZVzNWqXLSZpnuzc?appbar=false&editor=false&result=true&errorlist=false&theme=bootstrap5" backgroundimage "[Blazor SfPdfViewer Component](gettingstarted-images/blazor-pdfviewer.png)" %}
 

--- a/blazor/pdfviewer-2/getting-started/web-assembly-application.md
+++ b/blazor/pdfviewer-2/getting-started/web-assembly-application.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Getting Started with SfPdfViewer in Blazor WASM App | Syncfusion&reg;
+title: Getting Started with SfPdfViewer in Blazor WASM App | Syncfusion
 description: Checkout and learn about getting started with Blazor SfPdfViewer component in Blazor WebAssembly (WASM) App using Visual Studio and more.
 platform: Blazor
 control: SfPdfViewer

--- a/blazor/pdfviewer-2/getting-started/web-assembly-application.md
+++ b/blazor/pdfviewer-2/getting-started/web-assembly-application.md
@@ -83,7 +83,7 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 builder.Services.AddMemoryCache();
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 
-// Add Syncfusion&reg; Blazor service to the container.
+// Add Syncfusion Blazor service to the container.
 builder.Services.AddSyncfusionBlazor();
 await builder.Build().RunAsync();
 
@@ -98,9 +98,9 @@ Add the following stylesheet and script to the head section of the **wwwroot/ind
 {% highlight cshtml %}
 
 <head>
-    <!-- Syncfusion&reg; Blazor PDF Viewer control's theme style sheet -->
+    <!-- Syncfusion Blazor PDF Viewer control's theme style sheet -->
     <link href="_content/Syncfusion.Blazor.Themes/bootstrap5.css" rel="stylesheet" />
-    <!-- Syncfusion&reg; Blazor PDF Viewer control's scripts -->
+    <!-- Syncfusion Blazor PDF Viewer control's scripts -->
     <script src="_content/Syncfusion.Blazor.SfPdfViewer/scripts/syncfusion-blazor-sfpdfviewer.min.js" type="text/javascript"></script>
 </head>
 

--- a/blazor/pdfviewer-2/getting-started/wsl-application.md
+++ b/blazor/pdfviewer-2/getting-started/wsl-application.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Getting Started with SfPdfViewer in Blazor WSL mode | Syncfusion&reg;
+title: Getting Started with SfPdfViewer in Blazor WSL mode | Syncfusion
 description: Learn how to getting started with SfPdfViewer control in Blazor WSL (Windows Subsystem for Linux) mode. 
 platform: Blazor
 control: SfPdfViewer

--- a/blazor/pdfviewer-2/getting-started/wsl-application.md
+++ b/blazor/pdfviewer-2/getting-started/wsl-application.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Getting Started with SfPdfViewer in Blazor WSL mode | Syncfusion®
+title: Getting Started with SfPdfViewer in Blazor WSL mode | Syncfusion&reg;
 description: Learn how to getting started with SfPdfViewer control in Blazor WSL (Windows Subsystem for Linux) mode. 
 platform: Blazor
 control: SfPdfViewer
@@ -9,7 +9,7 @@ documentation: ug
 
 # Getting Started with Blazor PDF Viewer in WSL mode
 
-To run the Syncfusion® Blazor PDF Viewer component in WSL (Windows Subsystem for Linux) mode, follow these steps:
+To run the Syncfusion&reg; Blazor PDF Viewer component in WSL (Windows Subsystem for Linux) mode, follow these steps:
 
 **Step 1:** Enable the Windows Subsystem for Linux and the Virtual Machine Platform.
 

--- a/blazor/pdfviewer-2/globalization.md
+++ b/blazor/pdfviewer-2/globalization.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Globalization and RTL in Blazor SfPdfViewer | Syncfusion&reg;
-description: Checkout and learn here all about globalization and RTL in Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Globalization and RTL in Blazor SfPdfViewer Component | Syncfusion
+description: Checkout and learn here all about globalization and RTL in Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/globalization.md
+++ b/blazor/pdfviewer-2/globalization.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Globalization and RTL in Blazor SfPdfViewer Component | Syncfusion®
-description: Checkout and learn here all about globalization and RTL in Syncfusion® Blazor SfPdfViewer component and more.
+title: Globalization and RTL in Blazor SfPdfViewer Component | Syncfusion&reg;
+description: Checkout and learn here all about globalization and RTL in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug
@@ -11,7 +11,7 @@ documentation: ug
 
 ## Localization
 
-[Blazor SfPdfViewer](https://www.syncfusion.com/blazor-components/blazor-pdf-viewer) component can be localized. Refer to [Blazor Localization](https://blazor.syncfusion.com/documentation/common/localization) topic to localize Syncfusion® Blazor components.
+[Blazor SfPdfViewer](https://www.syncfusion.com/blazor-components/blazor-pdf-viewer) component can be localized. Refer to [Blazor Localization](https://blazor.syncfusion.com/documentation/common/localization) topic to localize Syncfusion&reg; Blazor components.
 
 ## Right to Left
 

--- a/blazor/pdfviewer-2/globalization.md
+++ b/blazor/pdfviewer-2/globalization.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Globalization and RTL in Blazor SfPdfViewer Component | Syncfusion&reg;
+title: Globalization and RTL in Blazor SfPdfViewer | Syncfusion&reg;
 description: Checkout and learn here all about globalization and RTL in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer

--- a/blazor/pdfviewer-2/hand-written-signature.md
+++ b/blazor/pdfviewer-2/hand-written-signature.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Handwritten Signature in Blazor SfPdfViewer | Syncfusion&reg;
-description: Checkout and learn here all about handwritten signature in Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Handwritten Signature in Blazor SfPdfViewer Component | Syncfusion
+description: Checkout and learn here all about handwritten signature in Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/hand-written-signature.md
+++ b/blazor/pdfviewer-2/hand-written-signature.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Handwritten Signature in Blazor SfPdfViewer Component | Syncfusion®
-description: Checkout and learn here all about handwritten signature in Syncfusion® Blazor SfPdfViewer component and more.
+title: Handwritten Signature in Blazor SfPdfViewer Component | Syncfusion&reg;
+description: Checkout and learn here all about handwritten signature in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/hand-written-signature.md
+++ b/blazor/pdfviewer-2/hand-written-signature.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Handwritten Signature in Blazor SfPdfViewer Component | Syncfusion&reg;
+title: Handwritten Signature in Blazor SfPdfViewer | Syncfusion&reg;
 description: Checkout and learn here all about handwritten signature in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer

--- a/blazor/pdfviewer-2/how-to/change-the-highlighted-color-of-the-text.md
+++ b/blazor/pdfviewer-2/how-to/change-the-highlighted-color-of-the-text.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Change highlight color text in Blazor PDF Viewer | Syncfusion&reg;
-description: Learn here all about how to change the highlighted color of the text in Syncfusion&reg; Blazor SfPdfViewer component.
+title: Change highlight color text in Blazor PDF Viewer | Syncfusion
+description: Learn here all about how to change the highlighted color of the text in Syncfusion Blazor SfPdfViewer component.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/change-the-highlighted-color-of-the-text.md
+++ b/blazor/pdfviewer-2/how-to/change-the-highlighted-color-of-the-text.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Change highlight color text in Blazor PDF Viewer | Syncfusion®
-description: Learn here all about how to change the highlighted color of the text in Syncfusion® Blazor SfPdfViewer component.
+title: Change highlight color text in Blazor PDF Viewer | Syncfusion&reg;
+description: Learn here all about how to change the highlighted color of the text in Syncfusion&reg; Blazor SfPdfViewer component.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/check-status-of-annotations-or-comments.md
+++ b/blazor/pdfviewer-2/how-to/check-status-of-annotations-or-comments.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Check the status of annotation in Blazor SfPdfViewer | Syncfusion&reg;
-description: Learn here all about how to check the status of annotations or comments in Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Check the status of annotations in Blazor SfPdfViewer | Syncfusion
+description: Learn here all about how to check the status of annotations or comments in Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/check-status-of-annotations-or-comments.md
+++ b/blazor/pdfviewer-2/how-to/check-status-of-annotations-or-comments.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Check the status of annotations in Blazor SfPdfViewer | Syncfusion®
-description: Learn here all about how to check the status of annotations or comments in Syncfusion® Blazor SfPdfViewer component and more.
+title: Check the status of annotations in Blazor SfPdfViewer | Syncfusion&reg;
+description: Learn here all about how to check the status of annotations or comments in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug
@@ -9,7 +9,7 @@ documentation: ug
 
 # Check the status of annotations or comments in Blazor SfPdfViewer
 
-The Syncfusion®'s Blazor SfPdfViewer component allows to check the status of the annotations in the SfPdfViewer using the [Review](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.Review.html) property of the [PdfAnnotation](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfAnnotation.html) class.
+The Syncfusion&reg; Blazor SfPdfViewer component allows to check the status of the annotations in the SfPdfViewer using the [Review](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.Review.html) property of the [PdfAnnotation](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfAnnotation.html) class.
 
 The following code example shows the review status of the annotation.
 

--- a/blazor/pdfviewer-2/how-to/check-status-of-annotations-or-comments.md
+++ b/blazor/pdfviewer-2/how-to/check-status-of-annotations-or-comments.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Check the status of annotations in Blazor SfPdfViewer | Syncfusion&reg;
+title: Check the status of annotation in Blazor SfPdfViewer | Syncfusion&reg;
 description: Learn here all about how to check the status of annotations or comments in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer

--- a/blazor/pdfviewer-2/how-to/check-whether-the-loaded-PDF-document-is-edited-or-not.md
+++ b/blazor/pdfviewer-2/how-to/check-whether-the-loaded-PDF-document-is-edited-or-not.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Check Document Editing Status in Blazor SfPdfViewer | Syncfusion&reg;
-description: Learn here all about how to check the editing status of the document in Syncfusion&reg; Blazor SfPdfViewer component.
+title: Check Document Editing Status in Blazor SfPdfViewer | Syncfusion
+description: Learn here all about how to check the editing status of the document in Syncfusion Blazor SfPdfViewer component.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/check-whether-the-loaded-PDF-document-is-edited-or-not.md
+++ b/blazor/pdfviewer-2/how-to/check-whether-the-loaded-PDF-document-is-edited-or-not.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Check Document Editing Status in Blazor SfPdfViewer | Syncfusion®
-description: Learn here all about how to check the editing status of the document in Syncfusion® Blazor SfPdfViewer component.
+title: Check Document Editing Status in Blazor SfPdfViewer | Syncfusion&reg;
+description: Learn here all about how to check the editing status of the document in Syncfusion&reg; Blazor SfPdfViewer component.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/create-pdf-document-in-the-created-event-of-sfpdfviewer.md
+++ b/blazor/pdfviewer-2/how-to/create-pdf-document-in-the-created-event-of-sfpdfviewer.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Create PDF document in the SfPdfViewer created event | Syncfusion®
-description: Learn here all about how to create PDF document in the created event of Syncfusion® Blazor SfPdfViewer component and more.
+title: Create PDF document in the SfPdfViewer created event | Syncfusion&reg;
+description: Learn here all about how to create PDF document in the created event of Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/create-pdf-document-in-the-created-event-of-sfpdfviewer.md
+++ b/blazor/pdfviewer-2/how-to/create-pdf-document-in-the-created-event-of-sfpdfviewer.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Create PDF document in the SfPdfViewer created event | Syncfusion&reg;
-description: Learn here all about how to create PDF document in the created event of Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Create PDF document in the SfPdfViewer created event | Syncfusion
+description: Learn here all about how to create PDF document in the created event of Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/create-sfpdfviewer-in-a-popup-window.md
+++ b/blazor/pdfviewer-2/how-to/create-sfpdfviewer-in-a-popup-window.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Create an SfPdfViewer within a popup window in Blazor | Syncfusion®
-description: Learn here all about Create SfPdfViewer in a popup window in Syncfusion® Blazor SfPdfViewer component and more.
+title: Create an SfPdfViewer within a popup window in Blazor | Syncfusion&reg;
+description: Learn here all about Create SfPdfViewer in a popup window in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug
@@ -9,7 +9,7 @@ documentation: ug
 
 # Create a SfPdfViewer within a popup window in Blazor
 
-For quick view, you might need to display the PDF file in a dialog window. The following code snippet explains how to use the SfPdfViewer component inside a dialog window. In this example, the Syncfusion®’s dialog component is used for Blazor.
+For quick view, you might need to display the PDF file in a dialog window. The following code snippet explains how to use the SfPdfViewer component inside a dialog window. In this example, the Syncfusion&reg;’s dialog component is used for Blazor.
 
 ```cshtml
 

--- a/blazor/pdfviewer-2/how-to/create-sfpdfviewer-in-a-popup-window.md
+++ b/blazor/pdfviewer-2/how-to/create-sfpdfviewer-in-a-popup-window.md
@@ -9,7 +9,7 @@ documentation: ug
 
 # Create a SfPdfViewer within a popup window in Blazor
 
-For quick view, you might need to display the PDF file in a dialog window. The following code snippet explains how to use the SfPdfViewer component inside a dialog window. In this example, the Syncfusion&reg;’s dialog component is used for Blazor.
+For quick view, you might need to display the PDF file in a dialog window. The following code snippet explains how to use the SfPdfViewer component inside a dialog window. In this example, the Syncfusion&reg; dialog component is used for Blazor.
 
 ```cshtml
 

--- a/blazor/pdfviewer-2/how-to/create-sfpdfviewer-in-a-popup-window.md
+++ b/blazor/pdfviewer-2/how-to/create-sfpdfviewer-in-a-popup-window.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Create an SfPdfViewer within a popup window in Blazor | Syncfusion&reg;
+title: Create a SfPdfViewer within a popup window in Blazor | Syncfusion&reg;
 description: Learn here all about Create SfPdfViewer in a popup window in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer

--- a/blazor/pdfviewer-2/how-to/create-sfpdfviewer-in-a-popup-window.md
+++ b/blazor/pdfviewer-2/how-to/create-sfpdfviewer-in-a-popup-window.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Create a SfPdfViewer within a popup window in Blazor | Syncfusion&reg;
-description: Learn here all about Create SfPdfViewer in a popup window in Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Create a SfPdfViewer within a popup window in Blazor | Syncfusion
+description: Learn here all about Create SfPdfViewer in a popup window in Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/create-sfpdfviewer-in-a-splitter-component.md
+++ b/blazor/pdfviewer-2/how-to/create-sfpdfviewer-in-a-splitter-component.md
@@ -9,7 +9,7 @@ documentation: ug
 
 # Create SfPdfViewer Component in a Splitter Component in Blazor
 
-You can use Splitter to render the SfPdfViewer while rendering more than one component. The following code snippet explains how to render the SfPdfViewer component inside a Splitter pane. In this example, the Syncfusion&reg;’s Splitter component is used to render SfPdfViewer.
+You can use Splitter to render the SfPdfViewer while rendering more than one component. The following code snippet explains how to render the SfPdfViewer component inside a Splitter pane. In this example, the Syncfusion&reg; Splitter component is used to render SfPdfViewer.
 
 ```cshtml
 

--- a/blazor/pdfviewer-2/how-to/create-sfpdfviewer-in-a-splitter-component.md
+++ b/blazor/pdfviewer-2/how-to/create-sfpdfviewer-in-a-splitter-component.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Create SfPdfViewer in a Splitter Component in Blazor | Syncfusion&reg;
-description: Learn here all about how to create SfPdfViewer in a Splitter Component in Syncfusion&reg; Blazor SfPdfViewer component.
+title: Create SfPdfViewer in a Splitter Component in Blazor | Syncfusion
+description: Learn here all about how to create SfPdfViewer in a Splitter Component in Syncfusion Blazor SfPdfViewer component.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/create-sfpdfviewer-in-a-splitter-component.md
+++ b/blazor/pdfviewer-2/how-to/create-sfpdfviewer-in-a-splitter-component.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Create SfPdfViewer in a Splitter Component in Blazor | Syncfusion®
-description: Learn here all about how to create SfPdfViewer in a Splitter Component in Syncfusion® Blazor SfPdfViewer component.
+title: Create SfPdfViewer in a Splitter Component in Blazor | Syncfusion&reg;
+description: Learn here all about how to create SfPdfViewer in a Splitter Component in Syncfusion&reg; Blazor SfPdfViewer component.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug
@@ -9,7 +9,7 @@ documentation: ug
 
 # Create SfPdfViewer Component in a Splitter Component in Blazor
 
-You can use Splitter to render the SfPdfViewer while rendering more than one component. The following code snippet explains how to render the SfPdfViewer component inside a Splitter pane. In this example, the Syncfusion®’s Splitter component is used to render SfPdfViewer.
+You can use Splitter to render the SfPdfViewer while rendering more than one component. The following code snippet explains how to render the SfPdfViewer component inside a Splitter pane. In this example, the Syncfusion&reg;’s Splitter component is used to render SfPdfViewer.
 
 ```cshtml
 

--- a/blazor/pdfviewer-2/how-to/create-sfpdfviewer.md
+++ b/blazor/pdfviewer-2/how-to/create-sfpdfviewer.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: View the created PDF document | Syncfusion&reg;
-description: Learn here all about View the created PDF document in Syncfusion&reg; Blazor SfPdfviewer component and more.
+title: View the created PDF document | Syncfusion
+description: Learn here all about View the created PDF document in Syncfusion Blazor SfPdfviewer component and more.
 platform: Blazor
 control: SfPdfviewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/create-sfpdfviewer.md
+++ b/blazor/pdfviewer-2/how-to/create-sfpdfviewer.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: View the created PDF document | Syncfusion®
-description: Learn here all about View the created PDF document in Syncfusion® Blazor SfPdfviewer component and more.
+title: View the created PDF document | Syncfusion&reg;
+description: Learn here all about View the created PDF document in Syncfusion&reg; Blazor SfPdfviewer component and more.
 platform: Blazor
 control: SfPdfviewer
 documentation: ug
@@ -9,7 +9,7 @@ documentation: ug
 
 # View the created PDF document
 
-The Syncfusion®'s Blazor SfPdfViewer component allows you to view the created PDF document using the [**Created**](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerEvents.html#Syncfusion_Blazor_SfPdfViewer_PdfViewerEvents_Created) event.
+The Syncfusion&reg; Blazor SfPdfViewer component allows you to view the created PDF document using the [**Created**](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerEvents.html#Syncfusion_Blazor_SfPdfViewer_PdfViewerEvents_Created) event.
 
 The following code example shows how to view the created PDF document.
 

--- a/blazor/pdfviewer-2/how-to/customize-arrow-annotation-heads.md
+++ b/blazor/pdfviewer-2/how-to/customize-arrow-annotation-heads.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Customize the arrow annotation heads in SfPdfviewer | Syncfusion®
-description: Learn here all about how to increase the connection buffer size in Syncfusion® Blazor SfPdfviewer component and more.
+title: Customize the arrow annotation heads in SfPdfviewer | Syncfusion&reg;
+description: Learn here all about how to increase the connection buffer size in Syncfusion&reg; Blazor SfPdfviewer component and more.
 platform: Blazor
 control: SfPdfviewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/customize-arrow-annotation-heads.md
+++ b/blazor/pdfviewer-2/how-to/customize-arrow-annotation-heads.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Customize the arrow annotation heads in SfPdfviewer | Syncfusion&reg;
-description: Learn here all about how to increase the connection buffer size in Syncfusion&reg; Blazor SfPdfviewer component and more.
+title: Customize the arrow annotation heads in SfPdfviewer | Syncfusion
+description: Learn here all about how to increase the connection buffer size in Syncfusion Blazor SfPdfviewer component and more.
 platform: Blazor
 control: SfPdfviewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/deploy-maui-using-android-emulator.md
+++ b/blazor/pdfviewer-2/how-to/deploy-maui-using-android-emulator.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Deploy SfPdfViewer in Blazor MAUI in windows | Syncfusion&reg;
-description: Learn how to deploy SfPdfViewer in Blazor MAUI Application on Windows in Syncfusion&reg; Blazor SfPdfViewer component and much more details.
+title: Deploy SfPdfViewer in Blazor MAUI in windows | Syncfusion
+description: Learn how to deploy SfPdfViewer in Blazor MAUI Application on Windows in Syncfusion Blazor SfPdfViewer component and much more details.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/deploy-maui-using-android-emulator.md
+++ b/blazor/pdfviewer-2/how-to/deploy-maui-using-android-emulator.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Deploy SfPdfViewer in Blazor MAUI in windows | Syncfusion®
-description: Learn how to deploy SfPdfViewer in Blazor MAUI Application on Windows in Syncfusion® Blazor SfPdfViewer component and much more details.
+title: Deploy SfPdfViewer in Blazor MAUI in windows | Syncfusion&reg;
+description: Learn how to deploy SfPdfViewer in Blazor MAUI Application on Windows in Syncfusion&reg; Blazor SfPdfViewer component and much more details.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug
@@ -15,7 +15,7 @@ Refer [here](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-sta
 
 ## Add PDF Viewer component
 
-Add the Syncfusion® PDF Viewer component in the **~/Pages/Index.razor** file.
+Add the Syncfusion&reg; PDF Viewer component in the **~/Pages/Index.razor** file.
 
 {% tabs %}
 {% highlight razor %}

--- a/blazor/pdfviewer-2/how-to/extract-particular-text-and-highlight.md
+++ b/blazor/pdfviewer-2/how-to/extract-particular-text-and-highlight.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Extract and Highlight Text in Blazor PDF Viewer | Syncfusion®
-description: Learn here all about how to extract specific text and highlight it in the Syncfusion® Blazor PDF Viewer component.
+title: Extract and Highlight Text in Blazor PDF Viewer | Syncfusion&reg;
+description: Learn here all about how to extract specific text and highlight it in the Syncfusion&reg; Blazor PDF Viewer component.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
@@ -9,11 +9,11 @@ documentation: ug
 
 # Extract and Highlight Text in Blazor PDF Viewer Component
 
-The Syncfusion® Blazor PDF Viewer component provides powerful capabilities to extract text from a PDF document and **highlight** specific text. This functionality enables users to interactively process PDF content, making it easier to emphasize important information.
+The Syncfusion&reg; Blazor PDF Viewer component provides powerful capabilities to extract text from a PDF document and **highlight** specific text. This functionality enables users to interactively process PDF content, making it easier to emphasize important information.
 
 To extract text, the PDF Viewer utilizes the **FindText** method, which identifies the positions of specified text within the PDF. Once the text is found, user can highlight it by creating a highlight annotation and adding it asynchronously using the [**AddAnnotationAsync**](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerBase.html#Syncfusion_Blazor_SfPdfViewer_PdfViewerBase_AddAnnotationAsync_Syncfusion_Blazor_SfPdfViewer_PdfAnnotation_) method.
 
-The following code example demonstrates how to extract text from a PDF document and highlight it in the Syncfusion® Blazor PDF Viewer component.
+The following code example demonstrates how to extract text from a PDF document and highlight it in the Syncfusion&reg; Blazor PDF Viewer component.
 
 ```cshtml
 @page "/"

--- a/blazor/pdfviewer-2/how-to/extract-particular-text-and-highlight.md
+++ b/blazor/pdfviewer-2/how-to/extract-particular-text-and-highlight.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Extract and Highlight Text in Blazor PDF Viewer | Syncfusion&reg;
-description: Learn here all about how to extract specific text and highlight it in the Syncfusion&reg; Blazor PDF Viewer component.
+title: Extract and Highlight Text in Blazor PDF Viewer | Syncfusion
+description: Learn here all about how to extract specific text and highlight it in the Syncfusion Blazor PDF Viewer component.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/get-data-from-sfpdfviewer.md
+++ b/blazor/pdfviewer-2/how-to/get-data-from-sfpdfviewer.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Get loaded PDF document's data from Blazor SfPdfViewer | Syncfusion&reg;
-description: Learn here all about how to get loaded PDF document's data in Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Get loaded PDF document's data from Blazor SfPdfViewer | Syncfusion
+description: Learn here all about how to get loaded PDF document's data in Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/get-data-from-sfpdfviewer.md
+++ b/blazor/pdfviewer-2/how-to/get-data-from-sfpdfviewer.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Get loaded PDF document's data from Blazor SfPdfViewer | Syncfusion®
-description: Learn here all about how to get loaded PDF document's data in Syncfusion® Blazor SfPdfViewer component and more.
+title: Get loaded PDF document's data from Blazor SfPdfViewer | Syncfusion&reg;
+description: Learn here all about how to get loaded PDF document's data in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/how-to-load-PDF-from-URL-to-server-side-PDF-viewer.md
+++ b/blazor/pdfviewer-2/how-to/how-to-load-PDF-from-URL-to-server-side-PDF-viewer.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: How to load PDF from URL to server-side PDF viewer | Syncfusion&reg;
-description: Learn here all about how to load PDf from URL on the server-side and load into Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: How to load PDF from URL to server-side PDF viewer | Syncfusion
+description: Learn here all about how to load PDf from URL on the server-side and load into Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/how-to-load-PDF-from-URL-to-server-side-PDF-viewer.md
+++ b/blazor/pdfviewer-2/how-to/how-to-load-PDF-from-URL-to-server-side-PDF-viewer.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: How to load PDF from URL to server-side PDF viewer | Syncfusion®
-description: Learn here all about how to load PDf from URL on the server-side and load into Syncfusion® Blazor SfPdfViewer component and more.
+title: How to load PDF from URL to server-side PDF viewer | Syncfusion&reg;
+description: Learn here all about how to load PDf from URL on the server-side and load into Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/identify-the-values-in-the-undo-redo-collections.md
+++ b/blazor/pdfviewer-2/how-to/identify-the-values-in-the-undo-redo-collections.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Identify if the Viewer has values in the Undo, Redo stack | Syncfusion®
-description: Learn how to identify if the Viewer has values in Undo, Redo stack in Syncfusion® Blazor SfPdfViewer component and more.
+title: Identify if the Viewer has values in the Undo, Redo stack | Syncfusion&reg;
+description: Learn how to identify if the Viewer has values in Undo, Redo stack in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug
@@ -9,7 +9,7 @@ documentation: ug
 
 # Identify if the SfPdfViewer has values in the Undo, Redo collections
 
-Syncfusion®'s Blazor SfPdfViewer component allows you to identify if the SfPdfViewer has values in the Undo and Redo collections using the [CanUndo](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerBase.html#Syncfusion_Blazor_SfPdfViewer_PdfViewerBase_CanUndo) and [CanRedo](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerBase.html#Syncfusion_Blazor_SfPdfViewer_PdfViewerBase_CanRedo) APIs of the SfPdfViewer.
+Syncfusion&reg; Blazor SfPdfViewer component allows you to identify if the SfPdfViewer has values in the Undo and Redo collections using the [CanUndo](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerBase.html#Syncfusion_Blazor_SfPdfViewer_PdfViewerBase_CanUndo) and [CanRedo](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerBase.html#Syncfusion_Blazor_SfPdfViewer_PdfViewerBase_CanRedo) APIs of the SfPdfViewer.
 
 The following code example shows how to achieve this based on the Undo Redo actions.
 

--- a/blazor/pdfviewer-2/how-to/identify-the-values-in-the-undo-redo-collections.md
+++ b/blazor/pdfviewer-2/how-to/identify-the-values-in-the-undo-redo-collections.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Identify if the Viewer has values in the Undo, Redo stack | Syncfusion&reg;
-description: Learn how to identify if the Viewer has values in Undo, Redo stack in Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Identify if the Viewer has values in the Undo, Redo stack | Syncfusion
+description: Learn how to identify if the Viewer has values in Undo, Redo stack in Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/import-annotations-as-objects.md
+++ b/blazor/pdfviewer-2/how-to/import-annotations-as-objects.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Import annotations as objects in SfPdfViewer Component | Syncfusion®
-description: Learn here all about Import annotations as objects in Syncfusion® Blazor SfPdfViewer component and more.
+title: Import annotations as objects in SfPdfViewer Component | Syncfusion&reg;
+description: Learn here all about Import annotations as objects in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug
@@ -9,7 +9,7 @@ documentation: ug
 
 # Import annotations as objects in Blazor SfPdfViewer Component
 
-The Syncfusion®'s Blazor SfPdfViewer component allows to import annotations from objects or streams instead of loading it as a file. To import such annotation objects, the SfPdfViewer control must export the PDF annotations as objects using the [ExportAnnotationsAsObjectAsync()](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerBase.html#Syncfusion_Blazor_SfPdfViewer_PdfViewerBase_ExportAnnotationsAsObjectAsync) method. Only the annotations objects that are exported from the SfPdfViewer can be imported.
+The Syncfusion&reg; Blazor SfPdfViewer component allows to import annotations from objects or streams instead of loading it as a file. To import such annotation objects, the SfPdfViewer control must export the PDF annotations as objects using the [ExportAnnotationsAsObjectAsync()](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerBase.html#Syncfusion_Blazor_SfPdfViewer_PdfViewerBase_ExportAnnotationsAsObjectAsync) method. Only the annotations objects that are exported from the SfPdfViewer can be imported.
 
 The following code example shows how to import annotations as objects, that are exported using the [ExportAnnotationsAsObjectAsync()](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerBase.html#Syncfusion_Blazor_SfPdfViewer_PdfViewerBase_ExportAnnotationsAsObjectAsync) method.
 

--- a/blazor/pdfviewer-2/how-to/import-annotations-as-objects.md
+++ b/blazor/pdfviewer-2/how-to/import-annotations-as-objects.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Import annotations as objects in SfPdfViewer Component | Syncfusion&reg;
-description: Learn here all about Import annotations as objects in Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Import annotations as objects in SfPdfViewer Component | Syncfusion
+description: Learn here all about Import annotations as objects in Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/improve-performance-using-CDN.md
+++ b/blazor/pdfviewer-2/how-to/improve-performance-using-CDN.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Improve the performance using CDN | Syncfusion&reg;
+title: Improve the performance using CDN | Syncfusion
 description: Learn here all about how to improve the performance using CDN in Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer

--- a/blazor/pdfviewer-2/how-to/improve-performance-using-CDN.md
+++ b/blazor/pdfviewer-2/how-to/improve-performance-using-CDN.md
@@ -17,9 +17,9 @@ The Syncfusion&reg; Blazor SfPdfViewer component allows to improve performance b
 ```html
 
 <head>
-    <!-- Syncfusion&reg; Blazor PDF Viewer control's theme style sheet -->
+    <!-- Syncfusion Blazor PDF Viewer control's theme style sheet -->
     <link href="https://cdn.syncfusion.com/blazor/25.1.35/styles/bootstrap5.css" rel="stylesheet" />
-    <!-- Syncfusion&reg; Blazor PDF Viewer control's scripts -->
+    <!-- Syncfusion Blazor PDF Viewer control's scripts -->
     <script src="https://cdn.syncfusion.com/blazor/25.1.35/syncfusion-blazor-sfpdfviewer.min.js" type="text/javascript"></script>
 </head>
 

--- a/blazor/pdfviewer-2/how-to/improve-performance-using-CDN.md
+++ b/blazor/pdfviewer-2/how-to/improve-performance-using-CDN.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Improve the performance using CDN | Syncfusion®
+title: Improve the performance using CDN | Syncfusion&reg;
 description: Learn here all about how to improve the performance using CDN in Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
@@ -11,15 +11,15 @@ documentation: ug
 
 When all the JavaScript files in the sample are referenced from the application's hosted location or NuGet location, each time we fetch them from that location, causing delays in fetching the script files. This delay can potentially slow down component rendering. To mitigate this performance issue, you can reference the script from a **CDN**. If the file is not available in the browser cache, it will be retrieved only from the hosted location. Subsequent fetches will retrieve the script file from the browser cache unless the file has been modified.
 
-The Syncfusion®'s Blazor SfPdfViewer component allows to improve performance by referring the below **CDN** link in **~/Pages/Layout.cshtml** or **~/Pages/_Host.cshtml** file.
+The Syncfusion&reg; Blazor SfPdfViewer component allows to improve performance by referring the below **CDN** link in **~/Pages/Layout.cshtml** or **~/Pages/_Host.cshtml** file.
 
 
 ```html
 
 <head>
-    <!-- Syncfusion® Blazor PDF Viewer control's theme style sheet -->
+    <!-- Syncfusion&reg; Blazor PDF Viewer control's theme style sheet -->
     <link href="https://cdn.syncfusion.com/blazor/25.1.35/styles/bootstrap5.css" rel="stylesheet" />
-    <!-- Syncfusion® Blazor PDF Viewer control's scripts -->
+    <!-- Syncfusion&reg; Blazor PDF Viewer control's scripts -->
     <script src="https://cdn.syncfusion.com/blazor/25.1.35/syncfusion-blazor-sfpdfviewer.min.js" type="text/javascript"></script>
 </head>
 

--- a/blazor/pdfviewer-2/how-to/increase-connection-buffer-size.md
+++ b/blazor/pdfviewer-2/how-to/increase-connection-buffer-size.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Increase the connection buffer size in Blazor SfPdfViewer | Syncfusion®
-description: Learn here all about how to increase the connection buffer size in Syncfusion® Blazor SfPdfViewer component and more.
+title: Increase the connection buffer size in Blazor SfPdfViewer | Syncfusion&reg;
+description: Learn here all about how to increase the connection buffer size in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug
@@ -9,7 +9,7 @@ documentation: ug
 
 # Increase the connection buffer size in Blazor SfPdfViewer Component
 
-The Syncfusion®'s Blazor SfPdfViewer component allows to increase the connection buffer size by adding the below service in program.cs file if the size of the SfPdfViewer is too large.
+The Syncfusion&reg; Blazor SfPdfViewer component allows to increase the connection buffer size by adding the below service in program.cs file if the size of the SfPdfViewer is too large.
 
 ```cshtml
 builder.Services.AddSignalR(o => { o.MaximumReceiveMessageSize = 102400000; });

--- a/blazor/pdfviewer-2/how-to/increase-connection-buffer-size.md
+++ b/blazor/pdfviewer-2/how-to/increase-connection-buffer-size.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Increase the connection buffer size in Blazor SfPdfViewer | Syncfusion&reg;
-description: Learn here all about how to increase the connection buffer size in Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Increase the connection buffer size in Blazor SfPdfViewer | Syncfusion
+description: Learn here all about how to increase the connection buffer size in Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/load-custom-font-pdfium.md
+++ b/blazor/pdfviewer-2/how-to/load-custom-font-pdfium.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Load Custom Fonts in a PDF Viewer | Syncfusion&reg;
-description: Learn here all about Custom Fonts in Blazor application in Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Load Custom Fonts in a PDF Viewer | Syncfusion
+description: Learn here all about Custom Fonts in Blazor application in Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/load-custom-font-pdfium.md
+++ b/blazor/pdfviewer-2/how-to/load-custom-font-pdfium.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Load Custom Fonts in a PDF Viewer | Syncfusion®
-description: Learn here all about Custom Fonts in Blazor application in Syncfusion® Blazor SfPdfViewer component and more.
+title: Load Custom Fonts in a PDF Viewer | Syncfusion&reg;
+description: Learn here all about Custom Fonts in Blazor application in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug
@@ -9,7 +9,7 @@ documentation: ug
 
 # Load Custom Fonts in a PDF Viewer
 
-Syncfusion® Blazor PDF Viewer utilizes Pdfium to extract the text and convert the PDF document as images. Pdfium supports a limited set of fonts by default. To expand this capability, [CustomFonts](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerBase.html#Syncfusion_Blazor_SfPdfViewer_PdfViewerBase_CustomFonts) can be used to load additional fonts that are not embedded within Pdfium.
+Syncfusion&reg; Blazor PDF Viewer utilizes Pdfium to extract the text and convert the PDF document as images. Pdfium supports a limited set of fonts by default. To expand this capability, [CustomFonts](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerBase.html#Syncfusion_Blazor_SfPdfViewer_PdfViewerBase_CustomFonts) can be used to load additional fonts that are not embedded within Pdfium.
 
 To implement CustomFonts, follow these steps: 
 

--- a/blazor/pdfviewer-2/how-to/load-desired-pdf-for-initial-loading-in-hosted-sample.md
+++ b/blazor/pdfviewer-2/how-to/load-desired-pdf-for-initial-loading-in-hosted-sample.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Load PDF for initial loading in Blazor SfPdfViewer | Syncfusion&reg;
-description: Learn here all about how to load desired PDF for initial loading in Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Load PDF for initial loading in Blazor SfPdfViewer | Syncfusion
+description: Learn here all about how to load desired PDF for initial loading in Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/load-desired-pdf-for-initial-loading-in-hosted-sample.md
+++ b/blazor/pdfviewer-2/how-to/load-desired-pdf-for-initial-loading-in-hosted-sample.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Load PDF for initial loading in Blazor SfPdfViewer | Syncfusion®
-description: Learn here all about how to load desired PDF for initial loading in Syncfusion® Blazor SfPdfViewer component and more.
+title: Load PDF for initial loading in Blazor SfPdfViewer | Syncfusion&reg;
+description: Learn here all about how to load desired PDF for initial loading in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/load-font-collection.md
+++ b/blazor/pdfviewer-2/how-to/load-font-collection.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Load Font Collection in a PDF Viewer | Syncfusion&reg;
-description: Learn here all about Font Collection in Blazor application in Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Load Font Collection in a PDF Viewer | Syncfusion
+description: Learn here all about Font Collection in Blazor application in Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/load-font-collection.md
+++ b/blazor/pdfviewer-2/how-to/load-font-collection.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Load Font Collection in a PDF Viewer | Syncfusion®
-description: Learn here all about Font Collection in Blazor application in Syncfusion® Blazor SfPdfViewer component and more.
+title: Load Font Collection in a PDF Viewer | Syncfusion&reg;
+description: Learn here all about Font Collection in Blazor application in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug
@@ -9,7 +9,7 @@ documentation: ug
 
 # Load Font collection in a PDF Viewer
 
-In addition to adding a single custom font, the Syncfusion® Blazor PDF Viewer also supports adding multiple fonts to the [FallbackFontCollection](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerBase.html#Syncfusion_Blazor_SfPdfViewer_PdfViewerBase_FallbackFontCollection). This is particularly useful when a PDF document utilizes various fonts that may not be embedded or supported by default on the viewing system. By configuring multiple fonts, you ensure that the document renders accurately, preserving its diverse font styles and special characters.
+In addition to adding a single custom font, the Syncfusion&reg; Blazor PDF Viewer also supports adding multiple fonts to the [FallbackFontCollection](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerBase.html#Syncfusion_Blazor_SfPdfViewer_PdfViewerBase_FallbackFontCollection). This is particularly useful when a PDF document utilizes various fonts that may not be embedded or supported by default on the viewing system. By configuring multiple fonts, you ensure that the document renders accurately, preserving its diverse font styles and special characters.
 
 To implement FallbackFontCollection, follow these step: 
 

--- a/blazor/pdfviewer-2/how-to/load-office-files.md
+++ b/blazor/pdfviewer-2/how-to/load-office-files.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Load office files in Blazor SfPdfViewer | Syncfusion&reg;
-description: Learn here all about how to load the microsoft office files like powerpoint in the Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Load office files in Blazor SfPdfViewer | Syncfusion
+description: Learn here all about how to load the microsoft office files like powerpoint in the Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/load-office-files.md
+++ b/blazor/pdfviewer-2/how-to/load-office-files.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Load office files in Blazor SfPdfViewer | Syncfusion®
-description: Learn here all about how to load the microsoft office files like powerpoint in the Syncfusion® Blazor SfPdfViewer component and more.
+title: Load office files in Blazor SfPdfViewer | Syncfusion&reg;
+description: Learn here all about how to load the microsoft office files like powerpoint in the Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/load-pdf-document-dynamically.md
+++ b/blazor/pdfviewer-2/how-to/load-pdf-document-dynamically.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Load PDF File dynamically in Blazor SfPdfViewer component| Syncfusion&reg;
-description: Learn here all about how to load PDF documents dynamically in Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Load PDF File dynamically in Blazor SfPdfViewer component| Syncfusion
+description: Learn here all about how to load PDF documents dynamically in Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/load-pdf-document-dynamically.md
+++ b/blazor/pdfviewer-2/how-to/load-pdf-document-dynamically.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Load PDF File dynamically in Blazor SfPdfViewer component| Syncfusion®
-description: Learn here all about how to load PDF documents dynamically in Syncfusion® Blazor SfPdfViewer component and more.
+title: Load PDF File dynamically in Blazor SfPdfViewer component| Syncfusion&reg;
+description: Learn here all about how to load PDF documents dynamically in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/move-scrollbar.md
+++ b/blazor/pdfviewer-2/how-to/move-scrollbar.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Move the scrollbar to the exact location of annotations | Syncfusion®
-description: Learn here all about move scrollbar to the exact location of annotations in Syncfusion® Blazor SfPdfViewer component and more.
+title: Move the scrollbar to the exact location of annotations | Syncfusion&reg;
+description: Learn here all about move scrollbar to the exact location of annotations in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug
@@ -9,7 +9,7 @@ documentation: ug
 
 # Move the scrollbar to the exact location of annotations
 
-The Syncfusion®'s Blazor SfPdfViewer component allows you to move the scrollbar to the exact location of annotations present in a loaded PDF document using the [GoToBookmarkAsync()](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerBase.html#Syncfusion_Blazor_SfPdfViewer_PdfViewerBase_GoToBookmarkAsync_System_Int32_System_Double_) method.
+The Syncfusion&reg; Blazor SfPdfViewer component allows you to move the scrollbar to the exact location of annotations present in a loaded PDF document using the [GoToBookmarkAsync()](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerBase.html#Syncfusion_Blazor_SfPdfViewer_PdfViewerBase_GoToBookmarkAsync_System_Int32_System_Double_) method.
 
 The following code example shows how to move the scrollbar to annotation location.
 

--- a/blazor/pdfviewer-2/how-to/move-scrollbar.md
+++ b/blazor/pdfviewer-2/how-to/move-scrollbar.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Move the scrollbar to the exact location of annotations | Syncfusion&reg;
-description: Learn here all about move scrollbar to the exact location of annotations in Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Move the scrollbar to the exact location of annotations | Syncfusion
+description: Learn here all about move scrollbar to the exact location of annotations in Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/perform-print-in-same-window.md
+++ b/blazor/pdfviewer-2/how-to/perform-print-in-same-window.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Perform print in same window using SfPdfViewer | Syncfusion®
-description: Learn here all about how to perform print in same window in Syncfusion® Blazor SfPdfViewer component and more.
+title: Perform print in same window using SfPdfViewer | Syncfusion&reg;
+description: Learn here all about how to perform print in same window in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/perform-print-in-same-window.md
+++ b/blazor/pdfviewer-2/how-to/perform-print-in-same-window.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Perform print in same window using SfPdfViewer | Syncfusion&reg;
-description: Learn here all about how to perform print in same window in Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Perform print in same window using SfPdfViewer | Syncfusion
+description: Learn here all about how to perform print in same window in Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/prevent-scrolling.md
+++ b/blazor/pdfviewer-2/how-to/prevent-scrolling.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Prevent the PDF from scrolling | Syncfusion®
-description: Learn here all about Create SfPdfViewer in a popup window in Syncfusion® Blazor SfPdfViewer component and more.
+title: Prevent the PDF from scrolling | Syncfusion&reg;
+description: Learn here all about Create SfPdfViewer in a popup window in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug
@@ -9,7 +9,7 @@ documentation: ug
 
 # Prevent the PDF from scrolling and remove the vertical scrollbar
 
-To prevent a PDF from scrolling and remove the vertical scroll bar in the Syncfusion® Blazor SfPdfViewer component, use CSS to set the `overflow` property of the component container to `hidden`.
+To prevent a PDF from scrolling and remove the vertical scroll bar in the Syncfusion&reg; Blazor SfPdfViewer component, use CSS to set the `overflow` property of the component container to `hidden`.
 
 By setting the overflow property to hidden, the SfPdfViewer component will be displayed without a vertical scrollbar, and the user will not be able to scroll the content of a PDF.
 

--- a/blazor/pdfviewer-2/how-to/prevent-scrolling.md
+++ b/blazor/pdfviewer-2/how-to/prevent-scrolling.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Prevent the PDF from scrolling | Syncfusion&reg;
-description: Learn here all about Create SfPdfViewer in a popup window in Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Prevent the PDF from scrolling | Syncfusion
+description: Learn here all about Create SfPdfViewer in a popup window in Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/print-the-sfpdfiewer-inside-the-dialog-component.md
+++ b/blazor/pdfviewer-2/how-to/print-the-sfpdfiewer-inside-the-dialog-component.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Print PDF Viewer inside the Dialog component in Blazor | Syncfusion®
-description: Learn here all about how to print the SfPdfViewer inside the Dialog in Syncfusion® Blazor SfPdfViewer component and more.
+title: Print PDF Viewer inside the Dialog component in Blazor | Syncfusion&reg;
+description: Learn here all about how to print the SfPdfViewer inside the Dialog in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/print-the-sfpdfiewer-inside-the-dialog-component.md
+++ b/blazor/pdfviewer-2/how-to/print-the-sfpdfiewer-inside-the-dialog-component.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Print PDF Viewer inside the Dialog component in Blazor | Syncfusion&reg;
-description: Learn here all about how to print the SfPdfViewer inside the Dialog in Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Print PDF Viewer inside the Dialog component in Blazor | Syncfusion
+description: Learn here all about how to print the SfPdfViewer inside the Dialog in Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/processing-large-files-without-increasing-maximum-message-size.md
+++ b/blazor/pdfviewer-2/how-to/processing-large-files-without-increasing-maximum-message-size.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Loading Large Files Without Increasing Maximum Message Size|Syncfusion®
+title: Loading Large Files Without Increasing Maximum Message Size|Syncfusion&reg;
 description: Learn here all about how to Processing Large Files Without Increasing Maximum Message Size in SfPdfViewer Component.
 platform: Blazor
 control: SfPdfViewer

--- a/blazor/pdfviewer-2/how-to/processing-large-files-without-increasing-maximum-message-size.md
+++ b/blazor/pdfviewer-2/how-to/processing-large-files-without-increasing-maximum-message-size.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Loading Large Files Without Increasing Maximum Message Size|Syncfusion&reg;
+title: Loading Large Files Without Increasing Maximum Message Size|Syncfusion
 description: Learn here all about how to Processing Large Files Without Increasing Maximum Message Size in SfPdfViewer Component.
 platform: Blazor
 control: SfPdfViewer

--- a/blazor/pdfviewer-2/how-to/reduce-slowness-while-running-the-wasm-sample-in-Visual-Studio.md
+++ b/blazor/pdfviewer-2/how-to/reduce-slowness-while-running-the-wasm-sample-in-Visual-Studio.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Reduce slowness while running the WASM sample | Syncfusion&reg;
+title: Reduce slowness while running the WASM sample | Syncfusion
 description: Learn here all about how to reduce slowness while running the WASM sample in Visual Studio and more.
 platform: Blazor
 control: SfPdfViewer

--- a/blazor/pdfviewer-2/how-to/reduce-slowness-while-running-the-wasm-sample-in-Visual-Studio.md
+++ b/blazor/pdfviewer-2/how-to/reduce-slowness-while-running-the-wasm-sample-in-Visual-Studio.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Reduce slowness while running the WASM sample | Syncfusion®
+title: Reduce slowness while running the WASM sample | Syncfusion&reg;
 description: Learn here all about how to reduce slowness while running the WASM sample in Visual Studio and more.
 platform: Blazor
 control: SfPdfViewer

--- a/blazor/pdfviewer-2/how-to/refer-SfPdfViewer-script-in-application.md
+++ b/blazor/pdfviewer-2/how-to/refer-SfPdfViewer-script-in-application.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Refer the SfPdfViewer script file in application | Syncfusion&reg;
-description: Learn here all about refer the SfPdfViewer script file in the application in Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Refer the SfPdfViewer script file in application | Syncfusion
+description: Learn here all about refer the SfPdfViewer script file in the application in Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/refer-SfPdfViewer-script-in-application.md
+++ b/blazor/pdfviewer-2/how-to/refer-SfPdfViewer-script-in-application.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Refer the SfPdfViewer script file in application | Syncfusion®
-description: Learn here all about refer the SfPdfViewer script file in the application in Syncfusion® Blazor SfPdfViewer component and more.
+title: Refer the SfPdfViewer script file in application | Syncfusion&reg;
+description: Learn here all about refer the SfPdfViewer script file in the application in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/render-ej2-pdf-viewer-in-blazor.md
+++ b/blazor/pdfviewer-2/how-to/render-ej2-pdf-viewer-in-blazor.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Render JS PDF Viewer inside Blazor SfPdfViewer Component | Syncfusion®
-description: Learn here all about how to render the JS SfPdfViewer in Syncfusion® Blazor SfPdfViewer component and more.
+title: Render JS PDF Viewer inside Blazor SfPdfViewer Component | Syncfusion&reg;
+description: Learn here all about how to render the JS SfPdfViewer in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug
@@ -9,7 +9,7 @@ documentation: ug
 
 # Render JS PDF Viewer inside Blazor SfPdfViewer Component
 
-The Syncfusion®'s Blazor SfPdfViewer component allows you to render the JS PDF Viewer component inside the blazor component.
+The Syncfusion&reg; Blazor SfPdfViewer component allows you to render the JS PDF Viewer component inside the blazor component.
 
 The following code example shows how to render the JS PDF Viewer component into the blazor component.
 

--- a/blazor/pdfviewer-2/how-to/render-ej2-pdf-viewer-in-blazor.md
+++ b/blazor/pdfviewer-2/how-to/render-ej2-pdf-viewer-in-blazor.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Render JS PDF Viewer inside Blazor SfPdfViewer Component | Syncfusion&reg;
-description: Learn here all about how to render the JS SfPdfViewer in Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Render JS PDF Viewer inside Blazor SfPdfViewer Component | Syncfusion
+description: Learn here all about how to render the JS SfPdfViewer in Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/render-n-pages-scrolling.md
+++ b/blazor/pdfviewer-2/how-to/render-n-pages-scrolling.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Render N number pages on scrolling | Syncfusion&reg;
-description: Learn here all about OverscanCount in Blazor application in Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Render N number pages on scrolling | Syncfusion
+description: Learn here all about OverscanCount in Blazor application in Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/render-n-pages-scrolling.md
+++ b/blazor/pdfviewer-2/how-to/render-n-pages-scrolling.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Render N number pages on scrolling | Syncfusion®
-description: Learn here all about OverscanCount in Blazor application in Syncfusion® Blazor SfPdfViewer component and more.
+title: Render N number pages on scrolling | Syncfusion&reg;
+description: Learn here all about OverscanCount in Blazor application in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug
@@ -11,7 +11,7 @@ documentation: ug
 
 The [OverscanCount](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerBase.html#Syncfusion_Blazor_SfPdfViewer_PdfViewerBase_OverscanCount) feature in a PDF Viewer allows users to preload/render specified number of pages before and after the visible view port when opening a PDF document, thereby enhance the scrolling experience.
  
-To utilize this capability in Syncfusion® PDF Viewer, adjust the OverscanCount property. By setting this property to a desired number, users can preload pages adjacent to the active page. This ensures quicker access to specific pages without waiting for the entire document to load.
+To utilize this capability in Syncfusion&reg; PDF Viewer, adjust the OverscanCount property. By setting this property to a desired number, users can preload pages adjacent to the active page. This ensures quicker access to specific pages without waiting for the entire document to load.
 
 Below is a code snippet illustrating how to implement the OverscanCount:
 

--- a/blazor/pdfviewer-2/how-to/show-or-hide-sfpdfviewer-dynamically.md
+++ b/blazor/pdfviewer-2/how-to/show-or-hide-sfpdfviewer-dynamically.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Show or hide the pdfviewer dynamically in Blazor | Syncfusion®
-description: Learn here all about how to show or hide the pdfviewer dynamically in Syncfusion® Blazor SfPdfViewer component and more.
+title: Show or hide the pdfviewer dynamically in Blazor | Syncfusion&reg;
+description: Learn here all about how to show or hide the pdfviewer dynamically in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/show-or-hide-sfpdfviewer-dynamically.md
+++ b/blazor/pdfviewer-2/how-to/show-or-hide-sfpdfviewer-dynamically.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Show or hide the pdfviewer dynamically in Blazor | Syncfusion&reg;
-description: Learn here all about how to show or hide the pdfviewer dynamically in Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Show or hide the pdfviewer dynamically in Blazor | Syncfusion
+description: Learn here all about how to show or hide the pdfviewer dynamically in Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/stretch-the-sfpdfviewer-size-to-its-container.md
+++ b/blazor/pdfviewer-2/how-to/stretch-the-sfpdfviewer-size-to-its-container.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Update the Viewer size to its container in SfPdfViewer | Syncfusion®
-description: Learn here all about how to stretch the SfPdfViewer size to its container in Syncfusion® Blazor SfPdfViewer component.
+title: Update the Viewer size to its container in SfPdfViewer | Syncfusion&reg;
+description: Learn here all about how to stretch the SfPdfViewer size to its container in Syncfusion&reg; Blazor SfPdfViewer component.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug
@@ -9,7 +9,7 @@ documentation: ug
 
 # Update the viewer size at run-time in Blazor SfPdfViewer Component
 
-You can stretch the SfPdfViewer size to its container size while resizing the container at runtime. The following code snippet explains how to update the SfPdfViewer size while resizing the Splitter at runtime. In this example, the Syncfusion®’s Splitter component is used.
+You can stretch the SfPdfViewer size to its container size while resizing the container at runtime. The following code snippet explains how to update the SfPdfViewer size while resizing the Splitter at runtime. In this example, the Syncfusion&reg;’s Splitter component is used.
 
 ```cshtml
 

--- a/blazor/pdfviewer-2/how-to/stretch-the-sfpdfviewer-size-to-its-container.md
+++ b/blazor/pdfviewer-2/how-to/stretch-the-sfpdfviewer-size-to-its-container.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Update the Viewer size to its container in SfPdfViewer | Syncfusion&reg;
-description: Learn here all about how to stretch the SfPdfViewer size to its container in Syncfusion&reg; Blazor SfPdfViewer component.
+title: Update the Viewer size to its container in SfPdfViewer | Syncfusion
+description: Learn here all about how to stretch the SfPdfViewer size to its container in Syncfusion Blazor SfPdfViewer component.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/stretch-the-sfpdfviewer-size-to-its-container.md
+++ b/blazor/pdfviewer-2/how-to/stretch-the-sfpdfviewer-size-to-its-container.md
@@ -9,7 +9,7 @@ documentation: ug
 
 # Update the viewer size at run-time in Blazor SfPdfViewer Component
 
-You can stretch the SfPdfViewer size to its container size while resizing the container at runtime. The following code snippet explains how to update the SfPdfViewer size while resizing the Splitter at runtime. In this example, the Syncfusion&reg;’s Splitter component is used.
+You can stretch the SfPdfViewer size to its container size while resizing the container at runtime. The following code snippet explains how to update the SfPdfViewer size while resizing the Splitter at runtime. In this example, the Syncfusion&reg; Splitter component is used.
 
 ```cshtml
 

--- a/blazor/pdfviewer-2/how-to/suppress-error-message.md
+++ b/blazor/pdfviewer-2/how-to/suppress-error-message.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Suppress the error dialog in the Blazor SfPdfViewer | Syncfusion®
-description: Learn here all about how to suppress the error dialog in Syncfusion® Blazor SfPdfViewer component and more.
+title: Suppress the error dialog in the Blazor SfPdfViewer | Syncfusion&reg;
+description: Learn here all about how to suppress the error dialog in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug
@@ -9,7 +9,7 @@ documentation: ug
 
 # Suppress the error dialog in Blazor SfPdfViewer Component
 
-The Syncfusion®'s Blazor SfPdfViewer component allows you to suppress or disable the error dialog box displayed in the SfPdfViewer using the [**EnableErrorDialog**](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerBase.html#Syncfusion_Blazor_SfPdfViewer_PdfViewerBase_EnableErrorDialog) property. The default value of the property is `true`.
+The Syncfusion&reg; Blazor SfPdfViewer component allows you to suppress or disable the error dialog box displayed in the SfPdfViewer using the [**EnableErrorDialog**](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerBase.html#Syncfusion_Blazor_SfPdfViewer_PdfViewerBase_EnableErrorDialog) property. The default value of the property is `true`.
 
 The following code example shows how to suppress the error dialog.
 

--- a/blazor/pdfviewer-2/how-to/suppress-error-message.md
+++ b/blazor/pdfviewer-2/how-to/suppress-error-message.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Suppress the error dialog in the Blazor SfPdfViewer | Syncfusion&reg;
-description: Learn here all about how to suppress the error dialog in Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Suppress the error dialog in the Blazor SfPdfViewer | Syncfusion
+description: Learn here all about how to suppress the error dialog in Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/unload-the-pdf-document-from-viewer.md
+++ b/blazor/pdfviewer-2/how-to/unload-the-pdf-document-from-viewer.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Unload the PDF document from Viewer in Blazor SfPdfViewer | Syncfusion®
-description: Learn here all about Unload the PDF document from Viewer in Syncfusion® Blazor SfPdfViewer component and more.
+title: Unload the PDF document from Viewer in Blazor SfPdfViewer | Syncfusion&reg;
+description: Learn here all about Unload the PDF document from Viewer in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/unload-the-pdf-document-from-viewer.md
+++ b/blazor/pdfviewer-2/how-to/unload-the-pdf-document-from-viewer.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Unload the PDF document from Viewer in Blazor SfPdfViewer | Syncfusion&reg;
-description: Learn here all about Unload the PDF document from Viewer in Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Unload the PDF document from Viewer in Blazor SfPdfViewer | Syncfusion
+description: Learn here all about Unload the PDF document from Viewer in Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/update-form-field-using-context-menu.md
+++ b/blazor/pdfviewer-2/how-to/update-form-field-using-context-menu.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Update formField using contextMenu in Blazor SfPdfViewer | Syncfusion®
-description: Learn here all about how to update form field using context menu in Syncfusion® Blazor SfPdfViewer component and more.
+title: Update formField using contextMenu in Blazor SfPdfViewer | Syncfusion&reg;
+description: Learn here all about how to update form field using context menu in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug
@@ -9,7 +9,7 @@ documentation: ug
 
 # Update form field using context menu in Blazor SfPdfViewer Component
 
-You can update the form field's at runtime using the [FormFieldClick event](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.FormFieldClickArgs.html) and [UpdateFormFieldsAsync()](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerBase.html#Syncfusion_Blazor_SfPdfViewer_PdfViewerBase_UpdateFormFieldsAsync_Syncfusion_Blazor_SfPdfViewer_FormField_) method of SfPdfViewer. The following code example explains how to open Context menu when you click on the form field and how to update the menu item content as form field's value. In this example, the Syncfusion®’s ContextMenu component is used to update form field.
+You can update the form field's at runtime using the [FormFieldClick event](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.FormFieldClickArgs.html) and [UpdateFormFieldsAsync()](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerBase.html#Syncfusion_Blazor_SfPdfViewer_PdfViewerBase_UpdateFormFieldsAsync_Syncfusion_Blazor_SfPdfViewer_FormField_) method of SfPdfViewer. The following code example explains how to open Context menu when you click on the form field and how to update the menu item content as form field's value. In this example, the Syncfusion&reg;’s ContextMenu component is used to update form field.
 
 
 ```cshtml

--- a/blazor/pdfviewer-2/how-to/update-form-field-using-context-menu.md
+++ b/blazor/pdfviewer-2/how-to/update-form-field-using-context-menu.md
@@ -9,7 +9,7 @@ documentation: ug
 
 # Update form field using context menu in Blazor SfPdfViewer Component
 
-You can update the form field's at runtime using the [FormFieldClick event](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.FormFieldClickArgs.html) and [UpdateFormFieldsAsync()](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerBase.html#Syncfusion_Blazor_SfPdfViewer_PdfViewerBase_UpdateFormFieldsAsync_Syncfusion_Blazor_SfPdfViewer_FormField_) method of SfPdfViewer. The following code example explains how to open Context menu when you click on the form field and how to update the menu item content as form field's value. In this example, the Syncfusion&reg;’s ContextMenu component is used to update form field.
+You can update the form field's at runtime using the [FormFieldClick event](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.FormFieldClickArgs.html) and [UpdateFormFieldsAsync()](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerBase.html#Syncfusion_Blazor_SfPdfViewer_PdfViewerBase_UpdateFormFieldsAsync_Syncfusion_Blazor_SfPdfViewer_FormField_) method of SfPdfViewer. The following code example explains how to open Context menu when you click on the form field and how to update the menu item content as form field's value. In this example, the Syncfusion&reg; ContextMenu component is used to update form field.
 
 
 ```cshtml

--- a/blazor/pdfviewer-2/how-to/update-form-field-using-context-menu.md
+++ b/blazor/pdfviewer-2/how-to/update-form-field-using-context-menu.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Update formField using contextMenu in Blazor SfPdfViewer | Syncfusion&reg;
-description: Learn here all about how to update form field using context menu in Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Update formField using contextMenu in Blazor SfPdfViewer | Syncfusion
+description: Learn here all about how to update form field using context menu in Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/how-to/view-docx-file-in-blazor-application.md
+++ b/blazor/pdfviewer-2/how-to/view-docx-file-in-blazor-application.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: View DOCX file in Blazor application using SfPdfViewer | Syncfusion®
-description: Learn here all about View DOCX file in Blazor application in Syncfusion® Blazor SfPdfViewer component and more.
+title: View DOCX file in Blazor application using SfPdfViewer | Syncfusion&reg;
+description: Learn here all about View DOCX file in Blazor application in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug
@@ -13,13 +13,13 @@ You can achieve this requirement of viewing DOCX file in two ways:.
 
 **Option** **1:**
 
-You can use Syncfusion®’s Word Processor component for Blazor to compose, view, and edit DOC, DOCX, RTF, and SFDT file formats.
+You can use Syncfusion&reg;’s Word Processor component for Blazor to compose, view, and edit DOC, DOCX, RTF, and SFDT file formats.
 
-To learn more about the [Word Processor component](https://www.syncfusion.com/blazor-components/blazor-word-processor), check out Syncfusion® online samples and documentation.
+To learn more about the [Word Processor component](https://www.syncfusion.com/blazor-components/blazor-word-processor), check out Syncfusion&reg; online samples and documentation.
 
 **Option** **2:**
 
-You can convert [Word document to PDF](https://help.syncfusion.com/file-formats/docio/word-to-pdf) using the Syncfusion®’s Word (DocIO) server-side library and view the resultant PDF file using SfPdfViewer component.
+You can convert [Word document to PDF](https://help.syncfusion.com/file-formats/docio/word-to-pdf) using the Syncfusion&reg;’s Word (DocIO) server-side library and view the resultant PDF file using SfPdfViewer component.
 
 N> You can refer to our [Blazor SfPdfViewer](https://www.syncfusion.com/blazor-components/blazor-pdf-viewer) feature tour page for its groundbreaking feature representations. You can also explore our [Blazor SfPdfViewer example](https://blazor.syncfusion.com/demos/pdf-viewer-2/default-functionalities?theme=bootstrap4) to understand how to explains core features of SfPdfViewer.
 

--- a/blazor/pdfviewer-2/how-to/view-docx-file-in-blazor-application.md
+++ b/blazor/pdfviewer-2/how-to/view-docx-file-in-blazor-application.md
@@ -13,13 +13,13 @@ You can achieve this requirement of viewing DOCX file in two ways:.
 
 **Option** **1:**
 
-You can use Syncfusion&reg;’s Word Processor component for Blazor to compose, view, and edit DOC, DOCX, RTF, and SFDT file formats.
+You can use Syncfusion&reg; Word Processor component for Blazor to compose, view, and edit DOC, DOCX, RTF, and SFDT file formats.
 
 To learn more about the [Word Processor component](https://www.syncfusion.com/blazor-components/blazor-word-processor), check out Syncfusion&reg; online samples and documentation.
 
 **Option** **2:**
 
-You can convert [Word document to PDF](https://help.syncfusion.com/file-formats/docio/word-to-pdf) using the Syncfusion&reg;’s Word (DocIO) server-side library and view the resultant PDF file using SfPdfViewer component.
+You can convert [Word document to PDF](https://help.syncfusion.com/file-formats/docio/word-to-pdf) using the Syncfusion&reg; Word (DocIO) server-side library and view the resultant PDF file using SfPdfViewer component.
 
 N> You can refer to our [Blazor SfPdfViewer](https://www.syncfusion.com/blazor-components/blazor-pdf-viewer) feature tour page for its groundbreaking feature representations. You can also explore our [Blazor SfPdfViewer example](https://blazor.syncfusion.com/demos/pdf-viewer-2/default-functionalities?theme=bootstrap4) to understand how to explains core features of SfPdfViewer.
 

--- a/blazor/pdfviewer-2/how-to/view-docx-file-in-blazor-application.md
+++ b/blazor/pdfviewer-2/how-to/view-docx-file-in-blazor-application.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: View DOCX file in Blazor application using SfPdfViewer | Syncfusion&reg;
-description: Learn here all about View DOCX file in Blazor application in Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: View DOCX file in Blazor application using SfPdfViewer | Syncfusion
+description: Learn here all about View DOCX file in Blazor application in Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/interaction.md
+++ b/blazor/pdfviewer-2/interaction.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Interaction mode in Blazor SfPdfViewer Component | Syncfusion&reg;
-description: Checkout and learn here all about interaction mode in Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Interaction mode in Blazor SfPdfViewer Component | Syncfusion
+description: Checkout and learn here all about interaction mode in Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/interaction.md
+++ b/blazor/pdfviewer-2/interaction.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Interaction mode in Blazor SfPdfViewer Component | Syncfusion®
-description: Checkout and learn here all about interaction mode in Syncfusion® Blazor SfPdfViewer component and more.
+title: Interaction mode in Blazor SfPdfViewer Component | Syncfusion&reg;
+description: Checkout and learn here all about interaction mode in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/magnification.md
+++ b/blazor/pdfviewer-2/magnification.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Magnification in Blazor SfPdfViewer Component | Syncfusion&reg;
-description: Checkout and learn here all about magnification in Syncfusion&reg; Blazor SfPdfViewer component and much more.
+title: Magnification in Blazor SfPdfViewer Component | Syncfusion
+description: Checkout and learn here all about magnification in Syncfusion Blazor SfPdfViewer component and much more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/magnification.md
+++ b/blazor/pdfviewer-2/magnification.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Magnification in Blazor SfPdfViewer Component | Syncfusion®
-description: Checkout and learn here all about magnification in Syncfusion® Blazor SfPdfViewer component and much more.
+title: Magnification in Blazor SfPdfViewer Component | Syncfusion&reg;
+description: Checkout and learn here all about magnification in Syncfusion&reg; Blazor SfPdfViewer component and much more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/migration.md
+++ b/blazor/pdfviewer-2/migration.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Migration from PDF Viewer (Classic) to PDF Viewer | Syncfusion®
+title: Migration from PDF Viewer (Classic) to PDF Viewer | Syncfusion&reg;
 description: This section explains the features available in the PDF Viewer control compared to PDF Viewer (Classic).
 platform: Blazor
 control: SfPdfViewer
@@ -83,9 +83,9 @@ N> The script file is same for `Server application` and `Web assembly applicatio
 {% highlight html tabtitle="(~/Layout.cshtml/Host.cshtml)" hl_lines="5" %}
 
 <head>
-    <!-- Syncfusion® Blazor PDF Viewer controls theme style sheet -->
+    <!-- Syncfusion&reg; Blazor PDF Viewer controls theme style sheet -->
     <link href="_content/Syncfusion.Blazor.Themes/bootstrap5.css" rel="stylesheet" />
-    <!-- Syncfusion® Blazor PDF Viewer controls scripts -->
+    <!-- Syncfusion&reg; Blazor PDF Viewer controls scripts -->
     <script src="_content/Syncfusion.Blazor.PdfViewer/scripts/syncfusion-blazor-pdfviewer.min.js" type="text/javascript"></script>
 </head>
 
@@ -102,9 +102,9 @@ N> The script file is same for `Server application` and `Web assembly applicatio
 {% highlight html tabtitle="(~/Layout.cshtml/Host.cshtml)" hl_lines="5" %}
 
 <head>
-    <!-- Syncfusion® Blazor SfPdfViewer controls theme style sheet -->
+    <!-- Syncfusion&reg; Blazor SfPdfViewer controls theme style sheet -->
     <link href="_content/Syncfusion.Blazor.Themes/bootstrap5.css" rel="stylesheet" />
-    <!-- Syncfusion® Blazor SfPdfViewer controls scripts -->
+    <!-- Syncfusion&reg; Blazor SfPdfViewer controls scripts -->
     <script src="_content/Syncfusion.Blazor.SfPdfViewer/scripts/syncfusion-blazor-sfpdfviewer.min.js" type="text/javascript"></script>
 </head>
 

--- a/blazor/pdfviewer-2/migration.md
+++ b/blazor/pdfviewer-2/migration.md
@@ -83,9 +83,9 @@ N> The script file is same for `Server application` and `Web assembly applicatio
 {% highlight html tabtitle="(~/Layout.cshtml/Host.cshtml)" hl_lines="5" %}
 
 <head>
-    <!-- Syncfusion&reg; Blazor PDF Viewer controls theme style sheet -->
+    <!-- Syncfusion Blazor PDF Viewer controls theme style sheet -->
     <link href="_content/Syncfusion.Blazor.Themes/bootstrap5.css" rel="stylesheet" />
-    <!-- Syncfusion&reg; Blazor PDF Viewer controls scripts -->
+    <!-- Syncfusion Blazor PDF Viewer controls scripts -->
     <script src="_content/Syncfusion.Blazor.PdfViewer/scripts/syncfusion-blazor-pdfviewer.min.js" type="text/javascript"></script>
 </head>
 
@@ -102,9 +102,9 @@ N> The script file is same for `Server application` and `Web assembly applicatio
 {% highlight html tabtitle="(~/Layout.cshtml/Host.cshtml)" hl_lines="5" %}
 
 <head>
-    <!-- Syncfusion&reg; Blazor SfPdfViewer controls theme style sheet -->
+    <!-- Syncfusion Blazor SfPdfViewer controls theme style sheet -->
     <link href="_content/Syncfusion.Blazor.Themes/bootstrap5.css" rel="stylesheet" />
-    <!-- Syncfusion&reg; Blazor SfPdfViewer controls scripts -->
+    <!-- Syncfusion Blazor SfPdfViewer controls scripts -->
     <script src="_content/Syncfusion.Blazor.SfPdfViewer/scripts/syncfusion-blazor-sfpdfviewer.min.js" type="text/javascript"></script>
 </head>
 

--- a/blazor/pdfviewer-2/migration.md
+++ b/blazor/pdfviewer-2/migration.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Migration from PDF Viewer (Classic) to PDF Viewer | Syncfusion&reg;
+title: Migration from PDF Viewer (Classic) to PDF Viewer | Syncfusion
 description: This section explains the features available in the PDF Viewer control compared to PDF Viewer (Classic).
 platform: Blazor
 control: SfPdfViewer

--- a/blazor/pdfviewer-2/navigation.md
+++ b/blazor/pdfviewer-2/navigation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Navigation in Blazor SfPdfViewer Component | Syncfusion&reg;
-description: Checkout and learn here all about navigation in Syncfusion&reg; Blazor SfPdfViewer component and much more.
+title: Navigation in Blazor SfPdfViewer Component | Syncfusion
+description: Checkout and learn here all about navigation in Syncfusion Blazor SfPdfViewer component and much more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/navigation.md
+++ b/blazor/pdfviewer-2/navigation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Navigation in Blazor SfPdfViewer Component | Syncfusion®
-description: Checkout and learn here all about navigation in Syncfusion® Blazor SfPdfViewer component and much more.
+title: Navigation in Blazor SfPdfViewer Component | Syncfusion&reg;
+description: Checkout and learn here all about navigation in Syncfusion&reg; Blazor SfPdfViewer component and much more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug
@@ -9,7 +9,7 @@ documentation: ug
 
 # Navigation in Blazor SfPdfViewer Component
 
-You can navigate between pages in Syncfusion® SfPdfViewer in the following ways:
+You can navigate between pages in Syncfusion&reg; SfPdfViewer in the following ways:
 
 * Scroll through the pages.
 * Click Go to pages in the built-in toolbar.

--- a/blazor/pdfviewer-2/open-pdf-file/from-amazon-s3.md
+++ b/blazor/pdfviewer-2/open-pdf-file/from-amazon-s3.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title:  Open PDF files from AWS S3 in SfPdfViewer Component | Syncfusion®
-description: Learn here all about how to Open PDF files from AWS S3 in Syncfusion® Blazor SfPdfViewer component and much more details.
+title:  Open PDF files from AWS S3 in SfPdfViewer Component | Syncfusion&reg;
+description: Learn here all about how to Open PDF files from AWS S3 in Syncfusion&reg; Blazor SfPdfViewer component and much more details.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/open-pdf-file/from-amazon-s3.md
+++ b/blazor/pdfviewer-2/open-pdf-file/from-amazon-s3.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title:  Open PDF files from AWS S3 in SfPdfViewer Component | Syncfusion&reg;
-description: Learn here all about how to Open PDF files from AWS S3 in Syncfusion&reg; Blazor SfPdfViewer component and much more details.
+title:  Open PDF files from AWS S3 in SfPdfViewer Component | Syncfusion
+description: Learn here all about how to Open PDF files from AWS S3 in Syncfusion Blazor SfPdfViewer component and much more details.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/open-pdf-file/from-azure-blob-storage.md
+++ b/blazor/pdfviewer-2/open-pdf-file/from-azure-blob-storage.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Open PDF files from Azure in SfPdfViewer Component | Syncfusion&reg;
-description: Learn here all about how to Open PDF files from Azure Blob Storage in Syncfusion&reg; Blazor SfPdfViewer component and much more details.
+title: Open PDF files from Azure in SfPdfViewer Component | Syncfusion
+description: Learn here all about how to Open PDF files from Azure Blob Storage in Syncfusion Blazor SfPdfViewer component and much more details.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/open-pdf-file/from-azure-blob-storage.md
+++ b/blazor/pdfviewer-2/open-pdf-file/from-azure-blob-storage.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Open PDF files from Azure in SfPdfViewer Component | Syncfusion®
-description: Learn here all about how to Open PDF files from Azure Blob Storage in Syncfusion® Blazor SfPdfViewer component and much more details.
+title: Open PDF files from Azure in SfPdfViewer Component | Syncfusion&reg;
+description: Learn here all about how to Open PDF files from Azure Blob Storage in Syncfusion&reg; Blazor SfPdfViewer component and much more details.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug
@@ -61,7 +61,7 @@ Start by following the steps provided in this [link](https://blazor.syncfusion.c
 }
 ```
 
-N> Replace **Your Connection string from Azure** with the actual connection string for your Azure Blob Storage account, **File Name to be Loaded into Syncfusion® SfPdfViewer** with the file name to load from the Azure container to the SfPdfViewer, and **Your container name in Azure** with the actual container name.
+N> Replace **Your Connection string from Azure** with the actual connection string for your Azure Blob Storage account, **File Name to be Loaded into Syncfusion&reg; SfPdfViewer** with the file name to load from the Azure container to the SfPdfViewer, and **Your container name in Azure** with the actual container name.
 
 N> The **Azure.Storage.Blobs** NuGet package must be installed in your application to use the previous code example.
 

--- a/blazor/pdfviewer-2/open-pdf-file/from-box-cloud-file-storage.md
+++ b/blazor/pdfviewer-2/open-pdf-file/from-box-cloud-file-storage.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Open PDF files from Box storage SfPdfViewer Component | Syncfusion&reg;
-description: Learn here all about how to Open PDF files from Box cloud file storage in Syncfusion&reg; Blazor SfPdfViewer component and much more details.
+title: Open PDF files from Box storage SfPdfViewer Component | Syncfusion
+description: Learn here all about how to Open PDF files from Box cloud file storage in Syncfusion Blazor SfPdfViewer component and much more details.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/open-pdf-file/from-box-cloud-file-storage.md
+++ b/blazor/pdfviewer-2/open-pdf-file/from-box-cloud-file-storage.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Open PDF files from Box storage SfPdfViewer Component | Syncfusion®
-description: Learn here all about how to Open PDF files from Box cloud file storage in Syncfusion® Blazor SfPdfViewer component and much more details.
+title: Open PDF files from Box storage SfPdfViewer Component | Syncfusion&reg;
+description: Learn here all about how to Open PDF files from Box cloud file storage in Syncfusion&reg; Blazor SfPdfViewer component and much more details.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/open-pdf-file/from-google-cloud-storage.md
+++ b/blazor/pdfviewer-2/open-pdf-file/from-google-cloud-storage.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Open PDF files from GCS in Blazor SfPdfViewer Component | Syncfusion&reg;
-description: Learn here all about how to Open PDF files from Google Cloud Storage in Syncfusion&reg; Blazor SfPdfViewer component and much more details.
+title: Open PDF files from GCS in Blazor SfPdfViewer Component | Syncfusion
+description: Learn here all about how to Open PDF files from Google Cloud Storage in Syncfusion Blazor SfPdfViewer component and much more details.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/open-pdf-file/from-google-cloud-storage.md
+++ b/blazor/pdfviewer-2/open-pdf-file/from-google-cloud-storage.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Open PDF files from GCS in Blazor SfPdfViewer Component | Syncfusion®
-description: Learn here all about how to Open PDF files from Google Cloud Storage in Syncfusion® Blazor SfPdfViewer component and much more details.
+title: Open PDF files from GCS in Blazor SfPdfViewer Component | Syncfusion&reg;
+description: Learn here all about how to Open PDF files from Google Cloud Storage in Syncfusion&reg; Blazor SfPdfViewer component and much more details.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug
@@ -63,7 +63,7 @@ Start by following the steps provided in this [link](https://blazor.syncfusion.c
 }
 ```
 
-N> Replace **Your Bucket name from Google Cloud Storage** with the actual name of your Google Cloud Storage bucket and **File Name to be Loaded into Syncfusion® SfPdfViewer** with the actual file name you want to load from the cloud bucket
+N> Replace **Your Bucket name from Google Cloud Storage** with the actual name of your Google Cloud Storage bucket and **File Name to be Loaded into Syncfusion&reg; SfPdfViewer** with the actual file name you want to load from the cloud bucket
 
 N> Replace **path/to/service-account-key.json** with the actual file path to your service account key JSON file. Make sure to provide the correct path and filename.
 

--- a/blazor/pdfviewer-2/open-pdf-file/from-google-drive.md
+++ b/blazor/pdfviewer-2/open-pdf-file/from-google-drive.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Open PDF files from Google Drive in SfPdfViewer Component | Syncfusion&reg;
-description: Learn here all about how to Open PDF files from Google Drive in Syncfusion&reg; Blazor SfPdfViewer component and much more details.
+title: Open PDF files from Google Drive in SfPdfViewer Component | Syncfusion
+description: Learn here all about how to Open PDF files from Google Drive in Syncfusion Blazor SfPdfViewer component and much more details.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/open-pdf-file/from-google-drive.md
+++ b/blazor/pdfviewer-2/open-pdf-file/from-google-drive.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Open PDF files from Google Drive in SfPdfViewer Component | Syncfusion®
-description: Learn here all about how to Open PDF files from Google Drive in Syncfusion® Blazor SfPdfViewer component and much more details.
+title: Open PDF files from Google Drive in SfPdfViewer Component | Syncfusion&reg;
+description: Learn here all about how to Open PDF files from Google Drive in Syncfusion&reg; Blazor SfPdfViewer component and much more details.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug
@@ -99,7 +99,7 @@ Start by following the steps provided in this [link](https://blazor.syncfusion.c
 
 ```
 
-N> Replace **Your Google Drive Folder ID** with your actual Google Drive folder ID, **Your Application name** with your actual application name, **File Name to be Loaded into Syncfusion® SfPdfViewer** with the actual file name you want to load from the Azure container to the Syncfusion® SfPdfViewer and **Your Path to the OAuth 2.0 Client IDs JSON file** with the actual path to your OAuth 2.0 Client IDs JSON file
+N> Replace **Your Google Drive Folder ID** with your actual Google Drive folder ID, **Your Application name** with your actual application name, **File Name to be Loaded into Syncfusion&reg; SfPdfViewer** with the actual file name you want to load from the Azure container to the Syncfusion&reg; SfPdfViewer and **Your Path to the OAuth 2.0 Client IDs JSON file** with the actual path to your OAuth 2.0 Client IDs JSON file
 
 N> The **FolderId** part is the unique identifier for the folder. For example, if your folder URL is: `https://drive.google.com/drive/folders/abc123xyz456`, then the folder ID is `abc123xyz456`.
 

--- a/blazor/pdfviewer-2/opening-pdf-file.md
+++ b/blazor/pdfviewer-2/opening-pdf-file.md
@@ -1,7 +1,7 @@
 ---
-title: "Opening PDF file in Blazor SfPdfViewer Component | Syncfusion&reg;"
+title: "Opening PDF file in Blazor SfPdfViewer Component | Syncfusion"
 component: "SfPdfViewer"
-description: "This page helps you to learn about how to load PDF files from various locations in Syncfusion&reg; Blazor SfPdfViewer."
+description: "This page helps you to learn about how to load PDF files from various locations in Syncfusion Blazor SfPdfViewer."
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/opening-pdf-file.md
+++ b/blazor/pdfviewer-2/opening-pdf-file.md
@@ -138,7 +138,7 @@ N> The **System.Data.SqlClient** package must be installed in your application t
 
 ## Opening a PDF from file system
 
-There is an UI option in built-in toolbar to open the PDF file from local file system. If you want to achieve the same functionality while designing your own toolbar, you can use the following code example to load and open the PDF file. In this sample, the Syncfusion&reg;’s Uploader control is used for Blazor.
+There is an UI option in built-in toolbar to open the PDF file from local file system. If you want to achieve the same functionality while designing your own toolbar, you can use the following code example to load and open the PDF file. In this sample, the Syncfusion&reg; Uploader control is used for Blazor.
 
 ```cshtml
 

--- a/blazor/pdfviewer-2/opening-pdf-file.md
+++ b/blazor/pdfviewer-2/opening-pdf-file.md
@@ -1,7 +1,7 @@
 ---
-title: "Opening PDF file in Blazor SfPdfViewer Component | Syncfusion®"
+title: "Opening PDF file in Blazor SfPdfViewer Component | Syncfusion&reg;"
 component: "SfPdfViewer"
-description: "This page helps you to learn about how to load PDF files from various locations in Syncfusion®'s Blazor SfPdfViewer."
+description: "This page helps you to learn about how to load PDF files from various locations in Syncfusion&reg; Blazor SfPdfViewer."
 platform: Blazor
 control: SfPdfViewer
 documentation: ug
@@ -56,7 +56,7 @@ The following code example shows how to open and load the PDF file stored in Azu
         BlobServiceClient blobServiceClient = new BlobServiceClient(connectionString);
         //Container Name
         string containerName = "pdf-file";
-        //File Name to be loaded into Syncfusion® SfPdfViewer
+        //File Name to be loaded into Syncfusion SfPdfViewer
         string fileName = "PDF_Succinctly.pdf";
         BlobContainerClient blobContainerClient = blobServiceClient.GetBlobContainerClient(containerName);
         BlockBlobClient blockBlobClient = blobContainerClient.GetBlockBlobClient(fileName);
@@ -86,7 +86,7 @@ N> The **Azure.Storage.Blobs** NuGet package must be installed in your applicati
         //Connection String of Storage Account
         string connectionString = "Here Place Your Connection string";
         string shareName = "pdfdocument";
-        //File Name to be loaded into Syncfusion® SfPdfViewer
+        //File Name to be loaded into Syncfusion SfPdfViewer
         string filePath = "Hive_Succinctly.pdf";
         ShareFileClient shareFileClient = new ShareFileClient(connectionString, shareName, filePath);
         Stream stream = shareFileClient.OpenRead();
@@ -138,7 +138,7 @@ N> The **System.Data.SqlClient** package must be installed in your application t
 
 ## Opening a PDF from file system
 
-There is an UI option in built-in toolbar to open the PDF file from local file system. If you want to achieve the same functionality while designing your own toolbar, you can use the following code example to load and open the PDF file. In this sample, the Syncfusion®’s Uploader control is used for Blazor.
+There is an UI option in built-in toolbar to open the PDF file from local file system. If you want to achieve the same functionality while designing your own toolbar, you can use the following code example to load and open the PDF file. In this sample, the Syncfusion&reg;’s Uploader control is used for Blazor.
 
 ```cshtml
 

--- a/blazor/pdfviewer-2/print.md
+++ b/blazor/pdfviewer-2/print.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Print in Blazor SfPdfViewer Component | Syncfusion&reg;
-description: Checkout and learn here all about print in Syncfusion&reg; Blazor SfPdfViewer component and much more details.
+title: Print in Blazor SfPdfViewer Component | Syncfusion
+description: Checkout and learn here all about print in Syncfusion Blazor SfPdfViewer component and much more details.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/print.md
+++ b/blazor/pdfviewer-2/print.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Print in Blazor SfPdfViewer Component | Syncfusion®
-description: Checkout and learn here all about print in Syncfusion® Blazor SfPdfViewer component and much more details.
+title: Print in Blazor SfPdfViewer Component | Syncfusion&reg;
+description: Checkout and learn here all about print in Syncfusion&reg; Blazor SfPdfViewer component and much more details.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/save-pdf-file/to-amazon-s3.md
+++ b/blazor/pdfviewer-2/save-pdf-file/to-amazon-s3.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Save PDF files to AWS S3 in SfPdfViewer Component | Syncfusion®
-description: Learn here all about how to save PDF files to AWS S3 in Syncfusion® Blazor SfPdfViewer component and much more details.
+title: Save PDF files to AWS S3 in SfPdfViewer Component | Syncfusion&reg;
+description: Learn here all about how to save PDF files to AWS S3 in Syncfusion&reg; Blazor SfPdfViewer component and much more details.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/save-pdf-file/to-amazon-s3.md
+++ b/blazor/pdfviewer-2/save-pdf-file/to-amazon-s3.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Save PDF files to AWS S3 in SfPdfViewer Component | Syncfusion&reg;
-description: Learn here all about how to save PDF files to AWS S3 in Syncfusion&reg; Blazor SfPdfViewer component and much more details.
+title: Save PDF files to AWS S3 in SfPdfViewer Component | Syncfusion
+description: Learn here all about how to save PDF files to AWS S3 in Syncfusion Blazor SfPdfViewer component and much more details.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/save-pdf-file/to-azure-blob-storage.md
+++ b/blazor/pdfviewer-2/save-pdf-file/to-azure-blob-storage.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Save PDF files to Azure Storage in SfPdfViewer Component | Syncfusion&reg;
-description: Learn here all about how to save PDF files to Azure Blob Storage in Syncfusion&reg; Blazor SfPdfViewer component and much more details.
+title: Save PDF files to Azure Storage in SfPdfViewer Component | Syncfusion
+description: Learn here all about how to save PDF files to Azure Blob Storage in Syncfusion Blazor SfPdfViewer component and much more details.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/save-pdf-file/to-azure-blob-storage.md
+++ b/blazor/pdfviewer-2/save-pdf-file/to-azure-blob-storage.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Save PDF files to Azure Storage in SfPdfViewer Component | Syncfusion®
-description: Learn here all about how to save PDF files to Azure Blob Storage in Syncfusion® Blazor SfPdfViewer component and much more details.
+title: Save PDF files to Azure Storage in SfPdfViewer Component | Syncfusion&reg;
+description: Learn here all about how to save PDF files to Azure Blob Storage in Syncfusion&reg; Blazor SfPdfViewer component and much more details.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug
@@ -72,7 +72,7 @@ Start by following the steps provided in this [link](https://blazor.syncfusion.c
 
 ```
 
-N> Replace **Your Connection string from Azure** with the actual connection string for your Azure Blob Storage account, **File Name to be Loaded into Syncfusion® SfPdfViewer** with the file name to load from the Azure container to the SfPdfViewer, and **Your container name in Azure** with the actual container name.
+N> Replace **Your Connection string from Azure** with the actual connection string for your Azure Blob Storage account, **File Name to be Loaded into Syncfusion&reg; SfPdfViewer** with the file name to load from the Azure container to the SfPdfViewer, and **Your container name in Azure** with the actual container name.
 
 N> The **Azure.Storage.Blobs** NuGet package must be installed in your application to use the previous code example.
 

--- a/blazor/pdfviewer-2/save-pdf-file/to-box-cloud-file-storage.md
+++ b/blazor/pdfviewer-2/save-pdf-file/to-box-cloud-file-storage.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Save PDF files to Box storage in  SfPdfViewer Component | Syncfusion®
-description: Learn here all about how to save PDF files to Box cloud file storage in Syncfusion® Blazor SfPdfViewer component and much more details.
+title: Save PDF files to Box storage in  SfPdfViewer Component | Syncfusion&reg;
+description: Learn here all about how to save PDF files to Box cloud file storage in Syncfusion&reg; Blazor SfPdfViewer component and much more details.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/save-pdf-file/to-box-cloud-file-storage.md
+++ b/blazor/pdfviewer-2/save-pdf-file/to-box-cloud-file-storage.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Save PDF files to Box storage in  SfPdfViewer Component | Syncfusion&reg;
-description: Learn here all about how to save PDF files to Box cloud file storage in Syncfusion&reg; Blazor SfPdfViewer component and much more details.
+title: Save PDF files to Box storage in  SfPdfViewer Component | Syncfusion
+description: Learn here all about how to save PDF files to Box cloud file storage in Syncfusion Blazor SfPdfViewer component and much more details.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/save-pdf-file/to-google-cloud-storage.md
+++ b/blazor/pdfviewer-2/save-pdf-file/to-google-cloud-storage.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Save PDF files to GCS in Blazor SfPdfViewer Component | Syncfusion&reg;
-description: Learn here all about how to Save PDF files to Google Cloud Storage in Syncfusion&reg; Blazor SfPdfViewer component and much more details.
+title: Save PDF files to GCS in Blazor SfPdfViewer Component | Syncfusion
+description: Learn here all about how to Save PDF files to Google Cloud Storage in Syncfusion Blazor SfPdfViewer component and much more details.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/save-pdf-file/to-google-cloud-storage.md
+++ b/blazor/pdfviewer-2/save-pdf-file/to-google-cloud-storage.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Save PDF files to GCS in Blazor SfPdfViewer Component | Syncfusion®
-description: Learn here all about how to Save PDF files to Google Cloud Storage in Syncfusion® Blazor SfPdfViewer component and much more details.
+title: Save PDF files to GCS in Blazor SfPdfViewer Component | Syncfusion&reg;
+description: Learn here all about how to Save PDF files to Google Cloud Storage in Syncfusion&reg; Blazor SfPdfViewer component and much more details.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug
@@ -70,7 +70,7 @@ Start by following the steps provided in this [link](https://blazor.syncfusion.c
 }
 ```
 
-N> Replace **Your Bucket name from Google Cloud Storage** with the actual name of your Google Cloud Storage bucket and **File Name to be Loaded into Syncfusion® SfPdfViewer** with the actual file name you want to load from the cloud bucket
+N> Replace **Your Bucket name from Google Cloud Storage** with the actual name of your Google Cloud Storage bucket and **File Name to be Loaded into Syncfusion&reg; SfPdfViewer** with the actual file name you want to load from the cloud bucket
 
 N> Replace **path/to/service-account-key.json** with the actual file path to your service account key JSON file. Make sure to provide the correct path and filename.
 

--- a/blazor/pdfviewer-2/save-pdf-file/to-google-drive.md
+++ b/blazor/pdfviewer-2/save-pdf-file/to-google-drive.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Save PDF files to Google Drive in SfPdfViewer Component | Syncfusion&reg;
-description: Learn here all about how to save PDF files to Google Drive in Syncfusion&reg; Blazor SfPdfViewer component and much more details.
+title: Save PDF files to Google Drive in SfPdfViewer Component | Syncfusion
+description: Learn here all about how to save PDF files to Google Drive in Syncfusion Blazor SfPdfViewer component and much more details.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/save-pdf-file/to-google-drive.md
+++ b/blazor/pdfviewer-2/save-pdf-file/to-google-drive.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Save PDF files to Google Drive in SfPdfViewer Component | Syncfusion®
-description: Learn here all about how to save PDF files to Google Drive in Syncfusion® Blazor SfPdfViewer component and much more details.
+title: Save PDF files to Google Drive in SfPdfViewer Component | Syncfusion&reg;
+description: Learn here all about how to save PDF files to Google Drive in Syncfusion&reg; Blazor SfPdfViewer component and much more details.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug
@@ -99,7 +99,7 @@ Start by following the steps provided in this [link](https://blazor.syncfusion.c
 
 ```
 
-N> Replace **Your Google Drive Folder ID** with your actual Google Drive folder ID, **Your Application name** with your actual application name, **File Name to be Loaded into Syncfusion® SfPdfViewer** with the actual file name you want to load from the Azure container to the Syncfusion® SfPdfViewer and **Your Path to the OAuth 2.0 Client IDs JSON file** with the actual path to your OAuth 2.0 Client IDs JSON file
+N> Replace **Your Google Drive Folder ID** with your actual Google Drive folder ID, **Your Application name** with your actual application name, **File Name to be Loaded into Syncfusion&reg; SfPdfViewer** with the actual file name you want to load from the Azure container to the Syncfusion&reg; SfPdfViewer and **Your Path to the OAuth 2.0 Client IDs JSON file** with the actual path to your OAuth 2.0 Client IDs JSON file
 
 N> The **FolderId** part is the unique identifier for the folder. For example, if your folder URL is: `https://drive.google.com/drive/folders/abc123xyz456`, then the folder ID is `abc123xyz456`.
 

--- a/blazor/pdfviewer-2/saving-pdf-file.md
+++ b/blazor/pdfviewer-2/saving-pdf-file.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Saving PDF file in Blazor SfPdfViewer Component | Syncfusion®
-description: Checkout and learn here all about saving PDF file in Syncfusion® Blazor SfPdfViewer component and more.
+title: Saving PDF file in Blazor SfPdfViewer Component | Syncfusion&reg;
+description: Checkout and learn here all about saving PDF file in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/saving-pdf-file.md
+++ b/blazor/pdfviewer-2/saving-pdf-file.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Saving PDF file in Blazor SfPdfViewer Component | Syncfusion&reg;
-description: Checkout and learn here all about saving PDF file in Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Saving PDF file in Blazor SfPdfViewer Component | Syncfusion
+description: Checkout and learn here all about saving PDF file in Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/text-search.md
+++ b/blazor/pdfviewer-2/text-search.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Text Search in Blazor SfPdfViewer Component | Syncfusion®
-description: Checkout and learn here all about text search in Syncfusion® Blazor SfPdfViewer component and much more.
+title: Text Search in Blazor SfPdfViewer Component | Syncfusion&reg;
+description: Checkout and learn here all about text search in Syncfusion&reg; Blazor SfPdfViewer component and much more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/text-search.md
+++ b/blazor/pdfviewer-2/text-search.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Text Search in Blazor SfPdfViewer Component | Syncfusion&reg;
-description: Checkout and learn here all about text search in Syncfusion&reg; Blazor SfPdfViewer component and much more.
+title: Text Search in Blazor SfPdfViewer Component | Syncfusion
+description: Checkout and learn here all about text search in Syncfusion Blazor SfPdfViewer component and much more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/toolbar-customization.md
+++ b/blazor/pdfviewer-2/toolbar-customization.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Toolbar Customization in Blazor SfPdfViewer Component | Syncfusion&reg;
-description: Checkout and learn here all about toolbar customization in Syncfusion&reg; Blazor SfPdfViewer component and more.
+title: Toolbar Customization in Blazor SfPdfViewer Component | Syncfusion
+description: Checkout and learn here all about toolbar customization in Syncfusion Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer-2/toolbar-customization.md
+++ b/blazor/pdfviewer-2/toolbar-customization.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Toolbar Customization in Blazor SfPdfViewer Component | Syncfusion®
-description: Checkout and learn here all about toolbar customization in Syncfusion® Blazor SfPdfViewer component and more.
+title: Toolbar Customization in Blazor SfPdfViewer Component | Syncfusion&reg;
+description: Checkout and learn here all about toolbar customization in Syncfusion&reg; Blazor SfPdfViewer component and more.
 platform: Blazor
 control: SfPdfViewer
 documentation: ug

--- a/blazor/pdfviewer/accessibility.md
+++ b/blazor/pdfviewer/accessibility.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Accessibility in Blazor PDF Viewer Component | Syncfusion&reg;
-description: Check out and learn here all about accessibility in the Syncfusion&reg; Blazor PDF Viewer component and more.
+title: Accessibility in Blazor PDF Viewer Component | Syncfusion
+description: Check out and learn here all about accessibility in the Syncfusion Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/accessibility.md
+++ b/blazor/pdfviewer/accessibility.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Accessibility in Blazor PDF Viewer Component | Syncfusion®
-description: Check out and learn here all about accessibility in the Syncfusion® Blazor PDF Viewer component and more.
+title: Accessibility in Blazor PDF Viewer Component | Syncfusion&reg;
+description: Check out and learn here all about accessibility in the Syncfusion&reg; Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
 ---
 
-# Accessibility in Syncfusion® Blazor PDF Viewer components
+# Accessibility in Syncfusion&reg; Blazor PDF Viewer components
 
 The Blazor PDF Viewer component followed the accessibility guidelines and standards, including [ADA](https://www.ada.gov/), [Section 508](https://www.section508.gov/), [WCAG 2.2](https://www.w3.org/TR/WCAG22/) standards, and [WCAG roles](https://www.w3.org/TR/wai-aria/#roles) that are commonly used to evaluate accessibility.
 

--- a/blazor/pdfviewer/annotation/comments.md
+++ b/blazor/pdfviewer/annotation/comments.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Comments in Blazor PDF Viewer Component | Syncfusion®
-description: Checkout and learn here all about comments in Syncfusion® Blazor PDF Viewer component and much more details.
+title: Comments in Blazor PDF Viewer Component | Syncfusion&reg;
+description: Checkout and learn here all about comments in Syncfusion&reg; Blazor PDF Viewer component and much more details.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
 ---
 
-N> Syncfusion® recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
+N> Syncfusion&reg; recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
 
 # Comments in Blazor PDF Viewer Component
 

--- a/blazor/pdfviewer/annotation/comments.md
+++ b/blazor/pdfviewer/annotation/comments.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Comments in Blazor PDF Viewer Component | Syncfusion&reg;
-description: Checkout and learn here all about comments in Syncfusion&reg; Blazor PDF Viewer component and much more details.
+title: Comments in Blazor PDF Viewer Component | Syncfusion
+description: Checkout and learn here all about comments in Syncfusion Blazor PDF Viewer component and much more details.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/annotation/free-text-annotation.md
+++ b/blazor/pdfviewer/annotation/free-text-annotation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Free text annotations in Blazor PDF Viewer Component | Syncfusion&reg;
-description: Checkout and learn here all about free text annotations in Syncfusion&reg; Blazor PDF Viewer component and more.
+title: Free text annotations in Blazor PDF Viewer Component | Syncfusion
+description: Checkout and learn here all about free text annotations in Syncfusion Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/annotation/free-text-annotation.md
+++ b/blazor/pdfviewer/annotation/free-text-annotation.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Free text annotations in Blazor PDF Viewer Component | Syncfusion®
-description: Checkout and learn here all about free text annotations in Syncfusion® Blazor PDF Viewer component and more.
+title: Free text annotations in Blazor PDF Viewer Component | Syncfusion&reg;
+description: Checkout and learn here all about free text annotations in Syncfusion&reg; Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
 ---
 
-N> Syncfusion® recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
+N> Syncfusion&reg; recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
 
 # Free text annotations in Blazor PDF Viewer Component
 

--- a/blazor/pdfviewer/annotation/import-export-annotation.md
+++ b/blazor/pdfviewer/annotation/import-export-annotation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Import and Export annotations in Blazor PDF Viewer | Syncfusion&reg;
-description: Learn here all about import and export annotations in Syncfusion&reg; Blazor PDF Viewer component and more.
+title: Import and Export annotations in Blazor PDF Viewer | Syncfusion
+description: Learn here all about import and export annotations in Syncfusion Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/annotation/import-export-annotation.md
+++ b/blazor/pdfviewer/annotation/import-export-annotation.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Import and Export annotations in Blazor PDF Viewer | Syncfusion®
-description: Learn here all about import and export annotations in Syncfusion® Blazor PDF Viewer component and more.
+title: Import and Export annotations in Blazor PDF Viewer | Syncfusion&reg;
+description: Learn here all about import and export annotations in Syncfusion&reg; Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
 ---
 
-N> Syncfusion® recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
+N> Syncfusion&reg; recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
 
 # Import and Export annotations in Blazor PDF Viewer Component
 

--- a/blazor/pdfviewer/annotation/ink-annotation.md
+++ b/blazor/pdfviewer/annotation/ink-annotation.md
@@ -1,7 +1,7 @@
 ---
-title: "Ink Annotation in Blazor PDF Viewer Component | Syncfusion&reg;"
+title: "Ink Annotation in Blazor PDF Viewer Component | Syncfusion"
 component: "PDF Viewer"
-description: "This page helps to learn about the Ink Annotation support with a code example in the Syncfusion&reg; Blazor PDF Viewer."
+description: "This page helps to learn about the Ink Annotation support with a code example in the Syncfusion Blazor PDF Viewer."
 ---
 
 N> Syncfusion&reg; recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.

--- a/blazor/pdfviewer/annotation/ink-annotation.md
+++ b/blazor/pdfviewer/annotation/ink-annotation.md
@@ -1,10 +1,10 @@
 ---
-title: "Ink Annotation in Blazor PDF Viewer Component | Syncfusion®"
+title: "Ink Annotation in Blazor PDF Viewer Component | Syncfusion&reg;"
 component: "PDF Viewer"
-description: "This page helps to learn about the Ink Annotation support with a code example in the Syncfusion®'s Blazor PDF Viewer."
+description: "This page helps to learn about the Ink Annotation support with a code example in the Syncfusion&reg; Blazor PDF Viewer."
 ---
 
-N> Syncfusion® recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
+N> Syncfusion&reg; recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
 
 # Ink Annotation in the Blazor PDF Viewer component
 

--- a/blazor/pdfviewer/annotation/measurement-annotation.md
+++ b/blazor/pdfviewer/annotation/measurement-annotation.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Measurement annotations in Blazor PDF Viewer Component | Syncfusion®
-description: Checkout and learn here all about measurement annotations in Syncfusion® Blazor PDF Viewer component and more.
+title: Measurement annotations in Blazor PDF Viewer Component | Syncfusion&reg;
+description: Checkout and learn here all about measurement annotations in Syncfusion&reg; Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
 ---
 
-N> Syncfusion® recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
+N> Syncfusion&reg; recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
 
 # Measurement annotations in Blazor PDF Viewer Component
 

--- a/blazor/pdfviewer/annotation/measurement-annotation.md
+++ b/blazor/pdfviewer/annotation/measurement-annotation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Measurement annotations in Blazor PDF Viewer Component | Syncfusion&reg;
-description: Checkout and learn here all about measurement annotations in Syncfusion&reg; Blazor PDF Viewer component and more.
+title: Measurement annotations in Blazor PDF Viewer Component | Syncfusion
+description: Checkout and learn here all about measurement annotations in Syncfusion Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/annotation/shape-annotation.md
+++ b/blazor/pdfviewer/annotation/shape-annotation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Shape annotations in Blazor PDF Viewer Component | Syncfusion&reg;
-description: Checkout and learn here all about shape annotations in Syncfusion&reg; Blazor PDF Viewer component and more.
+title: Shape annotations in Blazor PDF Viewer Component | Syncfusion
+description: Checkout and learn here all about shape annotations in Syncfusion Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/annotation/shape-annotation.md
+++ b/blazor/pdfviewer/annotation/shape-annotation.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Shape annotations in Blazor PDF Viewer Component | Syncfusion®
-description: Checkout and learn here all about shape annotations in Syncfusion® Blazor PDF Viewer component and more.
+title: Shape annotations in Blazor PDF Viewer Component | Syncfusion&reg;
+description: Checkout and learn here all about shape annotations in Syncfusion&reg; Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
 ---
 
-N> Syncfusion® recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
+N> Syncfusion&reg; recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
 
 # Shape annotations in Blazor PDF Viewer Component
 

--- a/blazor/pdfviewer/annotation/stamp-annotation.md
+++ b/blazor/pdfviewer/annotation/stamp-annotation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Stamp annotations in Blazor PDF Viewer Component | Syncfusion&reg;
-description: Checkout and learn here all about stamp annotations in Syncfusion&reg; Blazor PDF Viewer component and more.
+title: Stamp annotations in Blazor PDF Viewer Component | Syncfusion
+description: Checkout and learn here all about stamp annotations in Syncfusion Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/annotation/stamp-annotation.md
+++ b/blazor/pdfviewer/annotation/stamp-annotation.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Stamp annotations in Blazor PDF Viewer Component | Syncfusion®
-description: Checkout and learn here all about stamp annotations in Syncfusion® Blazor PDF Viewer component and more.
+title: Stamp annotations in Blazor PDF Viewer Component | Syncfusion&reg;
+description: Checkout and learn here all about stamp annotations in Syncfusion&reg; Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
 ---
 
-N> Syncfusion® recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
+N> Syncfusion&reg; recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
 
 # Stamp annotations in Blazor PDF Viewer Component
 

--- a/blazor/pdfviewer/annotation/sticky-notes-annotation.md
+++ b/blazor/pdfviewer/annotation/sticky-notes-annotation.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Sticky notes annotations in Blazor PDF Viewer Component | Syncfusion®
-description: Checkout and learn here all about sticky notes annotations in Syncfusion® Blazor PDF Viewer component and more.
+title: Sticky notes annotations in Blazor PDF Viewer Component | Syncfusion&reg;
+description: Checkout and learn here all about sticky notes annotations in Syncfusion&reg; Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
 ---
 
-N> Syncfusion® recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
+N> Syncfusion&reg; recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
 
 # Sticky notes annotations in Blazor PDF Viewer Component
 

--- a/blazor/pdfviewer/annotation/sticky-notes-annotation.md
+++ b/blazor/pdfviewer/annotation/sticky-notes-annotation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Sticky notes annotations in Blazor PDF Viewer Component | Syncfusion&reg;
-description: Checkout and learn here all about sticky notes annotations in Syncfusion&reg; Blazor PDF Viewer component and more.
+title: Sticky notes annotations in Blazor PDF Viewer Component | Syncfusion
+description: Checkout and learn here all about sticky notes annotations in Syncfusion Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/annotation/text-markup-annotation.md
+++ b/blazor/pdfviewer/annotation/text-markup-annotation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Text markup annotations in Blazor PDF Viewer Component | Syncfusion&reg;
-description: Checkout and learn here all about text markup annotations in Syncfusion&reg; Blazor PDF Viewer component and more.
+title: Text markup annotations in Blazor PDF Viewer Component | Syncfusion
+description: Checkout and learn here all about text markup annotations in Syncfusion Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/annotation/text-markup-annotation.md
+++ b/blazor/pdfviewer/annotation/text-markup-annotation.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Text markup annotations in Blazor PDF Viewer Component | Syncfusion®
-description: Checkout and learn here all about text markup annotations in Syncfusion® Blazor PDF Viewer component and more.
+title: Text markup annotations in Blazor PDF Viewer Component | Syncfusion&reg;
+description: Checkout and learn here all about text markup annotations in Syncfusion&reg; Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
 ---
 
-N> Syncfusion® recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
+N> Syncfusion&reg; recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
 
 # Text markup annotations in Blazor PDF Viewer Component
 

--- a/blazor/pdfviewer/deployment/aws-beanstalk-deployment.md
+++ b/blazor/pdfviewer/deployment/aws-beanstalk-deployment.md
@@ -59,7 +59,7 @@ var builder = WebApplication.CreateBuilder(args);
 // Add services to the container.
 builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor().AddHubOptions(o => { o.MaximumReceiveMessageSize = 102400000; });
-// Add Syncfusion&reg; Blazor service to the container.
+// Add Syncfusion Blazor service to the container.
 builder.Services.AddSyncfusionBlazor();
 
 var app = builder.Build();
@@ -79,9 +79,9 @@ Refer script and style sheet in the `<head>` of the **~/Pages/_Layout.cshtml**.
 
 <head>
     ....
-    <!-- Syncfusion&reg; Blazor PDF Viewer controls theme style sheet -->
+    <!-- Syncfusion Blazor PDF Viewer controls theme style sheet -->
     <link href="_content/Syncfusion.Blazor.Themes/bootstrap5.css" rel="stylesheet" />
-    <!-- Syncfusion&reg; Blazor PDF Viewer controls scripts -->
+    <!-- Syncfusion Blazor PDF Viewer controls scripts -->
     <script src="_content/Syncfusion.Blazor.PdfViewer/scripts/syncfusion-blazor-pdfviewer.min.js" type="text/javascript"></script>
 </head>
 

--- a/blazor/pdfviewer/deployment/aws-beanstalk-deployment.md
+++ b/blazor/pdfviewer/deployment/aws-beanstalk-deployment.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Blazor PDF Viewer deployment in AWS BeanStalk | Syncfusion&reg;
+title: Blazor PDF Viewer deployment in AWS BeanStalk | Syncfusion
 description: AWS Elastic Beanstalk simplifies the deployment and management of scalable web applications and services on Linux-based infrastructure
 platform: Blazor
 control: PDF Viewer

--- a/blazor/pdfviewer/deployment/aws-beanstalk-deployment.md
+++ b/blazor/pdfviewer/deployment/aws-beanstalk-deployment.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Blazor PDF Viewer deployment in AWS BeanStalk | Syncfusion®
+title: Blazor PDF Viewer deployment in AWS BeanStalk | Syncfusion&reg;
 description: AWS Elastic Beanstalk simplifies the deployment and management of scalable web applications and services on Linux-based infrastructure
 platform: Blazor
 control: PDF Viewer
@@ -32,7 +32,7 @@ To add Blazor PDF Viewer component in Blazor Server App and deploy it to AWS Ela
 * [Syncfusion.Blazor.Themes](https://www.nuget.org/packages/Syncfusion.Blazor.Themes/)
 * [SkiaSharp.NativeAssets.Linux.NoDependencies](https://www.nuget.org/packages/SkiaSharp.NativeAssets.Linux.NoDependencies/)
 
-## Register Syncfusion® Blazor Service
+## Register Syncfusion&reg; Blazor Service
 
 Open **~/_Imports.razor** file and import the **Syncfusion.Blazor** and **Syncfusion.Blazor.PdfViewerServer** namespaces.
 
@@ -45,7 +45,7 @@ Open **~/_Imports.razor** file and import the **Syncfusion.Blazor** and **Syncfu
 {% endhighlight %}
 {% endtabs %}
 
-Now, register the Syncfusion® Blazor Service in the Blazor Server App. Here
+Now, register the Syncfusion&reg; Blazor Service in the Blazor Server App. Here
 
 {% tabs %}
 {% highlight c# tabtitle=".NET 6 (~/Program.cs)" hl_lines="3 9 11" %}
@@ -59,7 +59,7 @@ var builder = WebApplication.CreateBuilder(args);
 // Add services to the container.
 builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor().AddHubOptions(o => { o.MaximumReceiveMessageSize = 102400000; });
-// Add Syncfusion® Blazor service to the container.
+// Add Syncfusion&reg; Blazor service to the container.
 builder.Services.AddSyncfusionBlazor();
 
 var app = builder.Build();
@@ -79,9 +79,9 @@ Refer script and style sheet in the `<head>` of the **~/Pages/_Layout.cshtml**.
 
 <head>
     ....
-    <!-- Syncfusion® Blazor PDF Viewer controls theme style sheet -->
+    <!-- Syncfusion&reg; Blazor PDF Viewer controls theme style sheet -->
     <link href="_content/Syncfusion.Blazor.Themes/bootstrap5.css" rel="stylesheet" />
-    <!-- Syncfusion® Blazor PDF Viewer controls scripts -->
+    <!-- Syncfusion&reg; Blazor PDF Viewer controls scripts -->
     <script src="_content/Syncfusion.Blazor.PdfViewer/scripts/syncfusion-blazor-pdfviewer.min.js" type="text/javascript"></script>
 </head>
 
@@ -90,7 +90,7 @@ Refer script and style sheet in the `<head>` of the **~/Pages/_Layout.cshtml**.
 
 ## Adding Blazor PDF Viewer Component
 
-Add the Syncfusion® PDF Viewer component in the **~/Pages/Index.razor** file.
+Add the Syncfusion&reg; PDF Viewer component in the **~/Pages/Index.razor** file.
 
 {% tabs %}
 {% highlight razor %}
@@ -105,7 +105,7 @@ private string DocumentPath { get; set; } = "wwwroot/Data/PDF_Succinctly.pdf";
 {% endhighlight %}
 {% endtabs %}
 
-Press <kbd>Ctrl</kbd>+<kbd>F5</kbd> (Windows) or <kbd>⌘</kbd>+<kbd>F5</kbd> (macOS) to run the application. Then, the Syncfusion® `Blazor PDF Viewer` component will be rendered in the default web browser.
+Press <kbd>Ctrl</kbd>+<kbd>F5</kbd> (Windows) or <kbd>⌘</kbd>+<kbd>F5</kbd> (macOS) to run the application. Then, the Syncfusion&reg; `Blazor PDF Viewer` component will be rendered in the default web browser.
 
 ## Steps to Configure the Linux VM used for deploying Blazor Server App in AWS Elastic Beanstalk Linux
 

--- a/blazor/pdfviewer/download.md
+++ b/blazor/pdfviewer/download.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Download in Blazor PDF Viewer Component | Syncfusion®
-description: Checkout and learn here all about download in Syncfusion® Blazor PDF Viewer component and much more details.
+title: Download in Blazor PDF Viewer Component | Syncfusion&reg;
+description: Checkout and learn here all about download in Syncfusion&reg; Blazor PDF Viewer component and much more details.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
 ---
 
-N> Syncfusion® recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
+N> Syncfusion&reg; recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
 
 # Download in Blazor PDF Viewer Component
 

--- a/blazor/pdfviewer/download.md
+++ b/blazor/pdfviewer/download.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Download in Blazor PDF Viewer Component | Syncfusion&reg;
-description: Checkout and learn here all about download in Syncfusion&reg; Blazor PDF Viewer component and much more details.
+title: Download in Blazor PDF Viewer Component | Syncfusion
+description: Checkout and learn here all about download in Syncfusion Blazor PDF Viewer component and much more details.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/events.md
+++ b/blazor/pdfviewer/events.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Events in Blazor PDF Viewer Component | Syncfusion&reg;
-description: Checkout and learn here all about events in Syncfusion&reg; Blazor PDF Viewer component and much more details.
+title: Events in Blazor PDF Viewer Component | Syncfusion
+description: Checkout and learn here all about events in Syncfusion Blazor PDF Viewer component and much more details.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/events.md
+++ b/blazor/pdfviewer/events.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Events in Blazor PDF Viewer Component | Syncfusion®
-description: Checkout and learn here all about events in Syncfusion® Blazor PDF Viewer component and much more details.
+title: Events in Blazor PDF Viewer Component | Syncfusion&reg;
+description: Checkout and learn here all about events in Syncfusion&reg; Blazor PDF Viewer component and much more details.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
 ---
 
-N> Syncfusion® recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
+N> Syncfusion&reg; recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
 
 # Events in Blazor PDF Viewer Component
 
@@ -62,7 +62,7 @@ The events provided in PDF Viewer component are listed out as follows:
 
 ## Adding PDF Viewer events to Blazor component
 
-The Syncfusion® PDF Viewer events has to be wrapped inside the `PdfViewerEvents` tag.
+The Syncfusion&reg; PDF Viewer events has to be wrapped inside the `PdfViewerEvents` tag.
 
 ```cshtml
 <SfPdfViewerServer DocumentPath="@DocumentPath" Height="500px" Width="1060px" >

--- a/blazor/pdfviewer/form-filling.md
+++ b/blazor/pdfviewer/form-filling.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Form filling in Blazor PDF Viewer Component | Syncfusion&reg;
-description: Checkout and learn here all about form filling in Syncfusion&reg; Blazor PDF Viewer component and much more.
+title: Form filling in Blazor PDF Viewer Component | Syncfusion
+description: Checkout and learn here all about form filling in Syncfusion Blazor PDF Viewer component and much more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/form-filling.md
+++ b/blazor/pdfviewer/form-filling.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Form filling in Blazor PDF Viewer Component | Syncfusion®
-description: Checkout and learn here all about form filling in Syncfusion® Blazor PDF Viewer component and much more.
+title: Form filling in Blazor PDF Viewer Component | Syncfusion&reg;
+description: Checkout and learn here all about form filling in Syncfusion&reg; Blazor PDF Viewer component and much more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
 ---
 
-N> Syncfusion® recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
+N> Syncfusion&reg; recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
 
 # Form filling in Blazor PDF Viewer Component
 

--- a/blazor/pdfviewer/getting-started/features.md
+++ b/blazor/pdfviewer/getting-started/features.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Overview of Blazor PDF Viewer Component | Syncfusion&reg;
-description: Checkout and learn about overview of the Syncfusion&reg; Blazor PDF Viewer component and much more details.
+title: Overview of Blazor PDF Viewer Component | Syncfusion
+description: Checkout and learn about overview of the Syncfusion Blazor PDF Viewer component and much more details.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/getting-started/features.md
+++ b/blazor/pdfviewer/getting-started/features.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Overview of Blazor PDF Viewer Component | Syncfusion®
-description: Checkout and learn about overview of the Syncfusion® Blazor PDF Viewer component and much more details.
+title: Overview of Blazor PDF Viewer Component | Syncfusion&reg;
+description: Checkout and learn about overview of the Syncfusion&reg; Blazor PDF Viewer component and much more details.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
 ---
 
-N> Syncfusion® recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
+N> Syncfusion&reg; recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
 
 # Overview of Blazor PDF Viewer Component
 
@@ -33,7 +33,7 @@ The [Blazor PDF Viewer component](https://www.syncfusion.com/blazor-components/b
 * FormFilling
 * Handwritten Signature
 
-N> Syncfusion® provides separate PDF Viewer component for Blazor Server and Blazor WebAssembly applications.
+N> Syncfusion&reg; provides separate PDF Viewer component for Blazor Server and Blazor WebAssembly applications.
 <br />For **Blazor WebAssembly App**, use [SfPdfViewer](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.PdfViewer.SfPdfViewer.html) component in Syncfusion.Blazor.PdfViewer NuGet package. This component requires server-side processing to render the PDF files through web service.
 <br />For **Blazor Server App**, use the [SfPdfViewerServer](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.PdfViewerServer.SfPdfViewerServer.html) component in corresponding NuGet based on the operating system of the server you intend to host, as shown below.,
 <br/>* For Windows, use [Syncfusion.Blazor.PdfViewerServer.Windows](https://www.nuget.org/packages/Syncfusion.Blazor.PdfViewerServer.Windows)

--- a/blazor/pdfviewer/getting-started/server-side-application.md
+++ b/blazor/pdfviewer/getting-started/server-side-application.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Getting Started with PDF Viewer in Blazor Server App | Syncfusion&reg;
+title: Getting Started with PDF Viewer in Blazor Server App | Syncfusion
 description: Learn how to getting started with PDF Viewer control in Blazor Server-side application. You can view and comment on PDFs in ease and also can fill fields.
 platform: Blazor
 control: PDF Viewer

--- a/blazor/pdfviewer/getting-started/server-side-application.md
+++ b/blazor/pdfviewer/getting-started/server-side-application.md
@@ -67,7 +67,7 @@ var builder = WebApplication.CreateBuilder(args);
 // Add services to the container.
 builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor().AddHubOptions(o => { o.MaximumReceiveMessageSize = 102400000; });
-// Add Syncfusion&reg; Blazor service to the container.
+// Add Syncfusion Blazor service to the container.
 builder.Services.AddSyncfusionBlazor();
 
 var app = builder.Build();
@@ -88,7 +88,7 @@ namespace BlazorApplication
         {
             services.AddRazorPages();
             services.AddServerSideBlazor();
-            // Add Syncfusion&reg; Blazor service to the container.
+            // Add Syncfusion Blazor service to the container.
             services.AddSyncfusionBlazor();
         }
         ...
@@ -110,7 +110,7 @@ Add the theme style sheet as below in the sever web app.
 {% highlight cshtml %}
 
 <head>
-    <!-- Syncfusion&reg; Blazor PDF Viewer controls theme style sheet -->
+    <!-- Syncfusion Blazor PDF Viewer controls theme style sheet -->
     <link href="_content/Syncfusion.Blazor.Themes/bootstrap5.css" rel="stylesheet" />
 </head>
 
@@ -132,9 +132,9 @@ Add the theme style sheet as below in the sever web app.
 
 <head>
     ....
-    <!-- Syncfusion&reg; Blazor PDF Viewer controls theme style sheet -->
+    <!-- Syncfusion Blazor PDF Viewer controls theme style sheet -->
     <link href="_content/Syncfusion.Blazor.Themes/bootstrap5.css" rel="stylesheet" />
-    <!-- Syncfusion&reg; Blazor PDF Viewer controls scripts -->
+    <!-- Syncfusion Blazor PDF Viewer controls scripts -->
     <script src="_content/Syncfusion.Blazor.PdfViewer/scripts/syncfusion-blazor-pdfviewer.min.js" type="text/javascript"></script>
 </head>
 

--- a/blazor/pdfviewer/getting-started/server-side-application.md
+++ b/blazor/pdfviewer/getting-started/server-side-application.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Getting Started with PDF Viewer in Blazor Server App | Syncfusion®
+title: Getting Started with PDF Viewer in Blazor Server App | Syncfusion&reg;
 description: Learn how to getting started with PDF Viewer control in Blazor Server-side application. You can view and comment on PDFs in ease and also can fill fields.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
 ---
 
-N> Syncfusion® recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
+N> Syncfusion&reg; recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
 
 # Getting Started with Blazor PDF Viewer Component in Blazor Server App
 
@@ -34,7 +34,7 @@ To add Blazor PDF Viewer component in Blazor Server App, use `SfPdfViewerServer`
 * For **Linux**, use [Syncfusion.Blazor.PdfViewerServer.Linux](https://www.nuget.org/packages/Syncfusion.Blazor.PdfViewerServer.Linux) and [Syncfusion.Blazor.Themes](https://www.nuget.org/packages/Syncfusion.Blazor.Themes/)
 * For **macOs**, use [Syncfusion.Blazor.PdfViewerServer.OSX](https://www.nuget.org/packages/Syncfusion.Blazor.PdfViewerServer.OSX)and [Syncfusion.Blazor.Themes](https://www.nuget.org/packages/Syncfusion.Blazor.Themes/)
 
-## Register Syncfusion® Blazor Service
+## Register Syncfusion&reg; Blazor Service
 
 Open **~/_Imports.razor** file and import the **Syncfusion.Blazor** and **Syncfusion.Blazor.PdfViewerServer** namespaces.
 
@@ -47,13 +47,13 @@ Open **~/_Imports.razor** file and import the **Syncfusion.Blazor** and **Syncfu
 {% endhighlight %}
 {% endtabs %}
 
-Now, register the Syncfusion® Blazor Service in the Blazor Server App. Here, Syncfusion® Blazor Service is registered by setting [IgnoreScriptIsolation](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.GlobalOptions.html#Syncfusion_Blazor_GlobalOptions_IgnoreScriptIsolation) property as true to load the scripts externally in the [next steps](#add-script-reference).
+Now, register the Syncfusion&reg; Blazor Service in the Blazor Server App. Here, Syncfusion&reg; Blazor Service is registered by setting [IgnoreScriptIsolation](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.GlobalOptions.html#Syncfusion_Blazor_GlobalOptions_IgnoreScriptIsolation) property as true to load the scripts externally in the [next steps](#add-script-reference).
 
 > From 2022 Vol-1 (20.1) version, the default value of `IgnoreScriptIsolation` is changed to `true`. It is not necessary to set the `IgnoreScriptIsolation` property to refer scripts externally, since the default value has already been changed to true, and this property is obsolete.
 
-* For **.NET 6 and .NET 7** app, open the **~/Program.cs** file and register the Syncfusion® Blazor Service.
+* For **.NET 6 and .NET 7** app, open the **~/Program.cs** file and register the Syncfusion&reg; Blazor Service.
 
-* For **.NET 5 and .NET 3.X** app, open the **~/Startup.cs** file and register the Syncfusion® Blazor Service.
+* For **.NET 5 and .NET 3.X** app, open the **~/Startup.cs** file and register the Syncfusion&reg; Blazor Service.
 
 {% tabs %}
 {% highlight c# tabtitle=".NET 6 & .NET 7 (~/Program.cs)" hl_lines="3 10" %}
@@ -67,7 +67,7 @@ var builder = WebApplication.CreateBuilder(args);
 // Add services to the container.
 builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor().AddHubOptions(o => { o.MaximumReceiveMessageSize = 102400000; });
-// Add Syncfusion® Blazor service to the container.
+// Add Syncfusion&reg; Blazor service to the container.
 builder.Services.AddSyncfusionBlazor();
 
 var app = builder.Build();
@@ -88,7 +88,7 @@ namespace BlazorApplication
         {
             services.AddRazorPages();
             services.AddServerSideBlazor();
-            // Add Syncfusion® Blazor service to the container.
+            // Add Syncfusion&reg; Blazor service to the container.
             services.AddSyncfusionBlazor();
         }
         ...
@@ -102,22 +102,22 @@ namespace BlazorApplication
 
 Add the theme style sheet as below in the sever web app.
 
-* For .NET 6 app, add the Syncfusion® bootstrap5 theme in the `<head>` of the **~/Pages/_Layout.cshtml** file.
+* For .NET 6 app, add the Syncfusion&reg; bootstrap5 theme in the `<head>` of the **~/Pages/_Layout.cshtml** file.
 
-* For .NET 3.X, .NET 5 and .NET 7 app, add the Syncfusion® bootstrap5 theme in the `<head>` of the **~/Pages/_Host.cshtml** file.
+* For .NET 3.X, .NET 5 and .NET 7 app, add the Syncfusion&reg; bootstrap5 theme in the `<head>` of the **~/Pages/_Host.cshtml** file.
 
 {% tabs %}
 {% highlight cshtml %}
 
 <head>
-    <!-- Syncfusion® Blazor PDF Viewer controls theme style sheet -->
+    <!-- Syncfusion&reg; Blazor PDF Viewer controls theme style sheet -->
     <link href="_content/Syncfusion.Blazor.Themes/bootstrap5.css" rel="stylesheet" />
 </head>
 
 {% endhighlight %}
 {% endtabs %}
 
-> Checkout the [Blazor Themes topic](https://blazor.syncfusion.com/documentation/appearance/themes) to learn different ways ([Static Web Assets](https://blazor.syncfusion.com/documentation/appearance/themes#static-web-assets), [CDN](https://blazor.syncfusion.com/documentation/appearance/themes#cdn-reference) and [CRG](https://blazor.syncfusion.com/documentation/common/custom-resource-generator)) to refer themes in Blazor application, and to have the expected appearance for Syncfusion® Blazor components. Here, the theme is referred using [Static Web Assets](https://blazor.syncfusion.com/documentation/appearance/themes#static-web-assets). Refer to [Enable static web assets usage](https://blazor.syncfusion.com/documentation/appearance/themes#enable-static-web-assets-usage) topic to use static assets in your project.
+> Checkout the [Blazor Themes topic](https://blazor.syncfusion.com/documentation/appearance/themes) to learn different ways ([Static Web Assets](https://blazor.syncfusion.com/documentation/appearance/themes#static-web-assets), [CDN](https://blazor.syncfusion.com/documentation/appearance/themes#cdn-reference) and [CRG](https://blazor.syncfusion.com/documentation/common/custom-resource-generator)) to refer themes in Blazor application, and to have the expected appearance for Syncfusion&reg; Blazor components. Here, the theme is referred using [Static Web Assets](https://blazor.syncfusion.com/documentation/appearance/themes#static-web-assets). Refer to [Enable static web assets usage](https://blazor.syncfusion.com/documentation/appearance/themes#enable-static-web-assets-usage) topic to use static assets in your project.
 
 ## Adding Script Reference
 
@@ -132,9 +132,9 @@ Add the theme style sheet as below in the sever web app.
 
 <head>
     ....
-    <!-- Syncfusion® Blazor PDF Viewer controls theme style sheet -->
+    <!-- Syncfusion&reg; Blazor PDF Viewer controls theme style sheet -->
     <link href="_content/Syncfusion.Blazor.Themes/bootstrap5.css" rel="stylesheet" />
-    <!-- Syncfusion® Blazor PDF Viewer controls scripts -->
+    <!-- Syncfusion&reg; Blazor PDF Viewer controls scripts -->
     <script src="_content/Syncfusion.Blazor.PdfViewer/scripts/syncfusion-blazor-pdfviewer.min.js" type="text/javascript"></script>
 </head>
 
@@ -143,11 +143,11 @@ Add the theme style sheet as below in the sever web app.
 
 > Checkout [Adding Script Reference topic](https://blazor.syncfusion.com/documentation/common/adding-script-references) to learn different ways to add script reference in Blazor Application.
 
-> Syncfusion® recommends to reference scripts using [Static Web Assets](https://blazor.syncfusion.com/documentation/common/adding-script-references#static-web-assets), [CDN](https://blazor.syncfusion.com/documentation/common/adding-script-references#cdn-reference) and [CRG](https://blazor.syncfusion.com/documentation/common/custom-resource-generator) by [disabling JavaScript isolation](https://blazor.syncfusion.com/documentation/common/adding-script-references#disable-javascript-isolation) for better loading performance of the Blazor application.
+> Syncfusion&reg; recommends to reference scripts using [Static Web Assets](https://blazor.syncfusion.com/documentation/common/adding-script-references#static-web-assets), [CDN](https://blazor.syncfusion.com/documentation/common/adding-script-references#cdn-reference) and [CRG](https://blazor.syncfusion.com/documentation/common/custom-resource-generator) by [disabling JavaScript isolation](https://blazor.syncfusion.com/documentation/common/adding-script-references#disable-javascript-isolation) for better loading performance of the Blazor application.
 
 ## Adding Blazor PDF Viewer Component
 
-Add the Syncfusion® PDF Viewer component in the **~/Pages/Index.razor** file.
+Add the Syncfusion&reg; PDF Viewer component in the **~/Pages/Index.razor** file.
 
 {% tabs %}
 {% highlight razor %}
@@ -164,7 +164,7 @@ private string DocumentPath { get; set; } = "wwwroot/Data/PDF_Succinctly.pdf";
 
 N> If the `DocumentPath` property value is not provided, the PDF Viewer component will be rendered without loading the PDF document. The users can then use the open option from the toolbar to browse and open the PDF as required.
 
-Press <kbd>Ctrl</kbd>+<kbd>F5</kbd> (Windows) or <kbd>⌘</kbd>+<kbd>F5</kbd> (macOS) to run the application. Then, the Syncfusion® `Blazor PDF Viewer` component will be rendered in the default web browser.
+Press <kbd>Ctrl</kbd>+<kbd>F5</kbd> (Windows) or <kbd>⌘</kbd>+<kbd>F5</kbd> (macOS) to run the application. Then, the Syncfusion&reg; `Blazor PDF Viewer` component will be rendered in the default web browser.
 
 ![Blazor PDFViewer Component](gettingstarted-images/blazor-pdfviewer.png)
 

--- a/blazor/pdfviewer/getting-started/web-assembly-application.md
+++ b/blazor/pdfviewer/getting-started/web-assembly-application.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Getting Started with PDF Viewer in Blazor WASM App | Syncfusion&reg;
+title: Getting Started with PDF Viewer in Blazor WASM App | Syncfusion
 description: Checkout and learn about getting started with Blazor PDF Viewer component in Blazor WebAssembly (WASM) App using Visual Studio and more.
 platform: Blazor
 control: PDF Viewer

--- a/blazor/pdfviewer/getting-started/web-assembly-application.md
+++ b/blazor/pdfviewer/getting-started/web-assembly-application.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Getting Started with PDF Viewer in Blazor WASM App | Syncfusion®
+title: Getting Started with PDF Viewer in Blazor WASM App | Syncfusion&reg;
 description: Checkout and learn about getting started with Blazor PDF Viewer component in Blazor WebAssembly (WASM) App using Visual Studio and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
 ---
 
-N> Syncfusion® recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
+N> Syncfusion&reg; recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
 
 # Getting Started with Blazor PDF Viewer Component in Blazor WASM App
 
@@ -33,7 +33,7 @@ To add Blazor PDF Viewer component in Blazor WebAssembly App, use `SfPdfViewer` 
 
 N> This component requires server-side processing to render the PDF files through web service
 
-## Register Syncfusion® Blazor Service
+## Register Syncfusion&reg; Blazor Service
 
 Open **~/_Imports.razor** file and import the Syncfusion.Blazor namespace.
 
@@ -45,11 +45,11 @@ Open **~/_Imports.razor** file and import the Syncfusion.Blazor namespace.
 {% endhighlight %}
 {% endtabs %}
 
-Now, register the Syncfusion® Blazor Service in the Blazor WebAssembly App. Here, Syncfusion® Blazor Service is registered by setting [IgnoreScriptIsolation](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.GlobalOptions.html#Syncfusion_Blazor_GlobalOptions_IgnoreScriptIsolation) property as true to load the scripts externally in the [next steps](#add-script-reference).
+Now, register the Syncfusion&reg; Blazor Service in the Blazor WebAssembly App. Here, Syncfusion&reg; Blazor Service is registered by setting [IgnoreScriptIsolation](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.GlobalOptions.html#Syncfusion_Blazor_GlobalOptions_IgnoreScriptIsolation) property as true to load the scripts externally in the [next steps](#add-script-reference).
 
 N> From 2022 Vol-1 (20.1) version, the default value of `IgnoreScriptIsolation` is changed to `true`. It is not necessary to set the `IgnoreScriptIsolation` property to refer scripts externally, since the default value has already been changed to true, and this property is obsolete.
 
-* Open **~/Program.cs** file and register the Syncfusion® Blazor Service in the client web app.
+* Open **~/Program.cs** file and register the Syncfusion&reg; Blazor Service in the client web app.
 
 {% tabs %}
 {% highlight C# tabtitle=".NET 6 & .NET 7 (~/Program.cs)" hl_lines="3 11" %}
@@ -108,7 +108,7 @@ Refer the theme style sheet from NuGet in the `<head>` of **wwwroot/index.html**
 {% endhighlight %}
 {% endtabs %}
 
-N> Checkout the [Blazor Themes topic](https://blazor.syncfusion.com/documentation/appearance/themes) to learn different ways ([Static Web Assets](https://blazor.syncfusion.com/documentation/appearance/themes#static-web-assets), [CDN](https://blazor.syncfusion.com/documentation/appearance/themes#cdn-reference) and [CRG](https://blazor.syncfusion.com/documentation/common/custom-resource-generator)) to refer themes in Blazor application, and to have the expected appearance for Syncfusion® Blazor components. Here, the theme is referred using [Static Web Assets](https://blazor.syncfusion.com/documentation/appearance/themes#static-web-assets). Refer to [Enable static web assets usage](https://blazor.syncfusion.com/documentation/appearance/themes#enable-static-web-assets-usage) topic to use static assets in your project.
+N> Checkout the [Blazor Themes topic](https://blazor.syncfusion.com/documentation/appearance/themes) to learn different ways ([Static Web Assets](https://blazor.syncfusion.com/documentation/appearance/themes#static-web-assets), [CDN](https://blazor.syncfusion.com/documentation/appearance/themes#cdn-reference) and [CRG](https://blazor.syncfusion.com/documentation/common/custom-resource-generator)) to refer themes in Blazor application, and to have the expected appearance for Syncfusion&reg; Blazor components. Here, the theme is referred using [Static Web Assets](https://blazor.syncfusion.com/documentation/appearance/themes#static-web-assets). Refer to [Enable static web assets usage](https://blazor.syncfusion.com/documentation/appearance/themes#enable-static-web-assets-usage) topic to use static assets in your project.
 
 ## Add Script Reference
 
@@ -130,7 +130,7 @@ Refer script in the `<head>` of the **~/index.html** file.
 
 N> Checkout [Adding Script Reference topic](https://blazor.syncfusion.com/documentation/common/adding-script-references) to learn different ways to add script reference in Blazor Application.
 
-N> Syncfusion® recommends to reference scripts using [Static Web Assets](https://blazor.syncfusion.com/documentation/common/adding-script-references#static-web-assets), [CDN](https://blazor.syncfusion.com/documentation/common/adding-script-references#cdn-reference) and [CRG](https://blazor.syncfusion.com/documentation/common/custom-resource-generator) by [disabling JavaScript isolation](https://blazor.syncfusion.com/documentation/common/adding-script-references#disable-javascript-isolation) for better loading performance of the Blazor application.
+N> Syncfusion&reg; recommends to reference scripts using [Static Web Assets](https://blazor.syncfusion.com/documentation/common/adding-script-references#static-web-assets), [CDN](https://blazor.syncfusion.com/documentation/common/adding-script-references#cdn-reference) and [CRG](https://blazor.syncfusion.com/documentation/common/custom-resource-generator) by [disabling JavaScript isolation](https://blazor.syncfusion.com/documentation/common/adding-script-references#disable-javascript-isolation) for better loading performance of the Blazor application.
 
 ## Add Blazor PDF Viewer Component
 
@@ -145,7 +145,7 @@ N> Syncfusion® recommends to reference scripts using [Static Web Assets](https:
 {% endhighlight %}
 {% endtabs %}
 
-* Now, add the Syncfusion® PDF Viewer component in razor file. Here, the PDF Viewer component is added in the **~/Pages/Index.razor** file under the **~/Pages** folder.
+* Now, add the Syncfusion&reg; PDF Viewer component in razor file. Here, the PDF Viewer component is added in the **~/Pages/Index.razor** file under the **~/Pages** folder.
 
 {% tabs %}
 {% highlight razor %}
@@ -159,11 +159,11 @@ N> [View Sample in GitHub](https://github.com/SyncfusionExamples/blazor-pdf-view
 
 ## Server side processing
 
-Since Syncfusion® PDF Viewer (Blazor WebAssembly) component depends on server-side processing to render the PDF files, it is mandatory to create a web service as mentioned [here](https://support.syncfusion.com/kb/article/8997/how-to-create-pdf-viewer-web-service-application-in-aspnet-core).
+Since Syncfusion&reg; PDF Viewer (Blazor WebAssembly) component depends on server-side processing to render the PDF files, it is mandatory to create a web service as mentioned [here](https://support.syncfusion.com/kb/article/8997/how-to-create-pdf-viewer-web-service-application-in-aspnet-core).
 
 N> [View web service sample in GitHub](https://github.com/SyncfusionExamples/EJ2-PDFViewer-WebServices)
 
-Press <kbd>Ctrl</kbd>+<kbd>F5</kbd> (Windows) or <kbd>⌘</kbd>+<kbd>F5</kbd> (macOS) to run the application. Then, the Syncfusion® `Blazor PDF Viewer` component will be rendered in the default web browser.
+Press <kbd>Ctrl</kbd>+<kbd>F5</kbd> (Windows) or <kbd>⌘</kbd>+<kbd>F5</kbd> (macOS) to run the application. Then, the Syncfusion&reg; `Blazor PDF Viewer` component will be rendered in the default web browser.
 
 ![Blazor PDF Viewer Component](gettingstarted-images/blazor-pdfviewer.png)
 

--- a/blazor/pdfviewer/getting-started/wsl-application.md
+++ b/blazor/pdfviewer/getting-started/wsl-application.md
@@ -1,17 +1,17 @@
 ---
 layout: post
-title: Getting Started with PDF Viewer in Blazor WSL mode | Syncfusion®
+title: Getting Started with PDF Viewer in Blazor WSL mode | Syncfusion&reg;
 description: Learn how to getting started with PDF Viewer control in Blazor WSL (Windows Subsystem for Linux) mode. 
 platform: Blazor
 control: PDF Viewer
 documentation: ug
 ---
 
-N> Syncfusion® recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
+N> Syncfusion&reg; recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
 
 # Getting Started with Blazor PDF Viewer Component in WSL mode
 
-To run the Syncfusion® Blazor PDF Viewer in WSL (Windows Subsystem for Linux) mode, follow these steps:
+To run the Syncfusion&reg; Blazor PDF Viewer in WSL (Windows Subsystem for Linux) mode, follow these steps:
 
 **Step 1:** Enable the Windows Subsystem for Linux and the Virtual Machine Platform.
 

--- a/blazor/pdfviewer/getting-started/wsl-application.md
+++ b/blazor/pdfviewer/getting-started/wsl-application.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Getting Started with PDF Viewer in Blazor WSL mode | Syncfusion&reg;
+title: Getting Started with PDF Viewer in Blazor WSL mode | Syncfusion
 description: Learn how to getting started with PDF Viewer control in Blazor WSL (Windows Subsystem for Linux) mode. 
 platform: Blazor
 control: PDF Viewer

--- a/blazor/pdfviewer/globalization.md
+++ b/blazor/pdfviewer/globalization.md
@@ -1,19 +1,19 @@
 ---
 layout: post
-title: Globalization and RTL in Blazor PDF Viewer Component | Syncfusion®
-description: Checkout and learn here all about globalization and RTL in Syncfusion® Blazor PDF Viewer component and more.
+title: Globalization and RTL in Blazor PDF Viewer Component | Syncfusion&reg;
+description: Checkout and learn here all about globalization and RTL in Syncfusion&reg; Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
 ---
 
-N> Syncfusion® recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
+N> Syncfusion&reg; recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
 
 # Globalization and RTL in Blazor PDF Viewer Component
 
 ## Localization
 
-[Blazor PDFViewer](https://www.syncfusion.com/blazor-components/blazor-pdf-viewer) component can be localized. Refer to [Blazor Localization](https://blazor.syncfusion.com/documentation/common/localization) topic to localize Syncfusion® Blazor components.
+[Blazor PDFViewer](https://www.syncfusion.com/blazor-components/blazor-pdf-viewer) component can be localized. Refer to [Blazor Localization](https://blazor.syncfusion.com/documentation/common/localization) topic to localize Syncfusion&reg; Blazor components.
 
 ## Right to Left
 

--- a/blazor/pdfviewer/globalization.md
+++ b/blazor/pdfviewer/globalization.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Globalization and RTL in Blazor PDF Viewer Component | Syncfusion&reg;
-description: Checkout and learn here all about globalization and RTL in Syncfusion&reg; Blazor PDF Viewer component and more.
+title: Globalization and RTL in Blazor PDF Viewer Component | Syncfusion
+description: Checkout and learn here all about globalization and RTL in Syncfusion Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/hand-written-signature.md
+++ b/blazor/pdfviewer/hand-written-signature.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Handwritten Signature in Blazor PDF Viewer Component | Syncfusion&reg;
-description: Checkout and learn here all about handwritten signature in Syncfusion&reg; Blazor PDF Viewer component and more.
+title: Handwritten Signature in Blazor PDF Viewer Component | Syncfusion
+description: Checkout and learn here all about handwritten signature in Syncfusion Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/hand-written-signature.md
+++ b/blazor/pdfviewer/hand-written-signature.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Handwritten Signature in Blazor PDF Viewer Component | Syncfusion®
-description: Checkout and learn here all about handwritten signature in Syncfusion® Blazor PDF Viewer component and more.
+title: Handwritten Signature in Blazor PDF Viewer Component | Syncfusion&reg;
+description: Checkout and learn here all about handwritten signature in Syncfusion&reg; Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
 ---
 
-N> Syncfusion® recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
+N> Syncfusion&reg; recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
 
 # Handwritten Signature in Blazor PDF Viewer Component
 

--- a/blazor/pdfviewer/how-to/authorization-token.md
+++ b/blazor/pdfviewer/how-to/authorization-token.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Include the Authorization token in Blazor PDF Viewer | Syncfusion&reg;
-description: Learn here all about how to include the authorization token in Syncfusion&reg; Blazor PDF Viewer component and more.
+title: Include the Authorization token in Blazor PDF Viewer | Syncfusion
+description: Learn here all about how to include the authorization token in Syncfusion Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/authorization-token.md
+++ b/blazor/pdfviewer/how-to/authorization-token.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Include the Authorization token in Blazor PDF Viewer | Syncfusion®
-description: Learn here all about how to include the authorization token in Syncfusion® Blazor PDF Viewer component and more.
+title: Include the Authorization token in Blazor PDF Viewer | Syncfusion&reg;
+description: Learn here all about how to include the authorization token in Syncfusion&reg; Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
@@ -9,7 +9,7 @@ documentation: ug
 
 # Include the Authorization token in Blazor PDF Viewer Component
 
-The Syncfusion®'s Blazor PDF Viewer component allows to include the authorization token in the PDF viewer AJAX request using the properties of the ajaxRequest header available in [`AjaxRequestSettings`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.PdfViewer.PdfViewerBase.html#Syncfusion_Blazor_PdfViewer_PdfViewerBase_AjaxRequestSettings), and it will be included in every AJAX request send from PDF Viewer.
+The Syncfusion&reg; Blazor PDF Viewer component allows to include the authorization token in the PDF viewer AJAX request using the properties of the ajaxRequest header available in [`AjaxRequestSettings`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.PdfViewer.PdfViewerBase.html#Syncfusion_Blazor_PdfViewer_PdfViewerBase_AjaxRequestSettings), and it will be included in every AJAX request send from PDF Viewer.
 
 The following code example shows how include the authorization token.
 

--- a/blazor/pdfviewer/how-to/change-the-highlighted-color-of-the-text.md
+++ b/blazor/pdfviewer/how-to/change-the-highlighted-color-of-the-text.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Change the text highlight color in Blazor PDF Viewer | Syncfusion®
-description: Learn here all about how to change the highlighted color of the text in Syncfusion® Blazor PDF Viewer component.
+title: Change the text highlight color in Blazor PDF Viewer | Syncfusion&reg;
+description: Learn here all about how to change the highlighted color of the text in Syncfusion&reg; Blazor PDF Viewer component.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/change-the-highlighted-color-of-the-text.md
+++ b/blazor/pdfviewer/how-to/change-the-highlighted-color-of-the-text.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Change the text highlight color in Blazor PDF Viewer | Syncfusion&reg;
-description: Learn here all about how to change the highlighted color of the text in Syncfusion&reg; Blazor PDF Viewer component.
+title: Change the text highlight color in Blazor PDF Viewer | Syncfusion
+description: Learn here all about how to change the highlighted color of the text in Syncfusion Blazor PDF Viewer component.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/check-status-of-annotations-or-comments.md
+++ b/blazor/pdfviewer/how-to/check-status-of-annotations-or-comments.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Check the status of annotations in Blazor PDF Viewer | Syncfusion®
-description: Learn here all about how to check the status of annotations or comments in Syncfusion® Blazor PDF Viewer component and more.
+title: Check the status of annotations in Blazor PDF Viewer | Syncfusion&reg;
+description: Learn here all about how to check the status of annotations or comments in Syncfusion&reg; Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
@@ -9,7 +9,7 @@ documentation: ug
 
 # Check the status of annotations in Blazor PDF Viewer Component
 
-The Syncfusion®'s Blazor PDF Viewer component allows to check the status of the annotations in the PDF viewer using the [Review](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.PdfViewer.Review.html) property of the [PdfAnnotation](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.PdfViewer.PdfAnnotation.html) class.
+The Syncfusion&reg; Blazor PDF Viewer component allows to check the status of the annotations in the PDF viewer using the [Review](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.PdfViewer.Review.html) property of the [PdfAnnotation](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.PdfViewer.PdfAnnotation.html) class.
 
 The following code example shows the review status of the annotation.
 

--- a/blazor/pdfviewer/how-to/check-status-of-annotations-or-comments.md
+++ b/blazor/pdfviewer/how-to/check-status-of-annotations-or-comments.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Check the status of annotations in Blazor PDF Viewer | Syncfusion&reg;
-description: Learn here all about how to check the status of annotations or comments in Syncfusion&reg; Blazor PDF Viewer component and more.
+title: Check the status of annotations in Blazor PDF Viewer | Syncfusion
+description: Learn here all about how to check the status of annotations or comments in Syncfusion Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/check-whether-the-loaded-PDF-document-is-edited-or-not.md
+++ b/blazor/pdfviewer/how-to/check-whether-the-loaded-PDF-document-is-edited-or-not.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Check the document editing status in PDF Viewer | Syncfusion®
-description: Learn here all about how to check the editing status of the document in Syncfusion® Blazor PDF Viewer component.
+title: Check the document editing status in PDF Viewer | Syncfusion&reg;
+description: Learn here all about how to check the editing status of the document in Syncfusion&reg; Blazor PDF Viewer component.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/check-whether-the-loaded-PDF-document-is-edited-or-not.md
+++ b/blazor/pdfviewer/how-to/check-whether-the-loaded-PDF-document-is-edited-or-not.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Check the document editing status in PDF Viewer | Syncfusion&reg;
-description: Learn here all about how to check the editing status of the document in Syncfusion&reg; Blazor PDF Viewer component.
+title: Check the document editing status in PDF Viewer | Syncfusion
+description: Learn here all about how to check the editing status of the document in Syncfusion Blazor PDF Viewer component.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/client-side-error.md
+++ b/blazor/pdfviewer/how-to/client-side-error.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Resolve the “Client-side error” in .Net 6.0 | Syncfusion®
+title: Resolve the “Client-side error” in .Net 6.0 | Syncfusion&reg;
 description: Learn here all about resolve the “Client-side error is found” issue in .Net 6.0 which uses System.Text.Json for serialization.
 platform: Blazor
 control: PDF Viewer

--- a/blazor/pdfviewer/how-to/client-side-error.md
+++ b/blazor/pdfviewer/how-to/client-side-error.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Resolve the “Client-side error” in .Net 6.0 | Syncfusion&reg;
+title: Resolve the “Client-side error” in .Net 6.0 | Syncfusion
 description: Learn here all about resolve the “Client-side error is found” issue in .Net 6.0 which uses System.Text.Json for serialization.
 platform: Blazor
 control: PDF Viewer

--- a/blazor/pdfviewer/how-to/create-pdf-document-in-the-created-event-of-pdf-viewer.md
+++ b/blazor/pdfviewer/how-to/create-pdf-document-in-the-created-event-of-pdf-viewer.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Create PDF document in the PDF Viewer created event | Syncfusion®
-description: Learn here all about how to create PDF document in the created event of Syncfusion® Blazor PDF Viewer component and more.
+title: Create PDF document in the PDF Viewer created event | Syncfusion&reg;
+description: Learn here all about how to create PDF document in the created event of Syncfusion&reg; Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/create-pdf-document-in-the-created-event-of-pdf-viewer.md
+++ b/blazor/pdfviewer/how-to/create-pdf-document-in-the-created-event-of-pdf-viewer.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Create PDF document in the PDF Viewer created event | Syncfusion&reg;
-description: Learn here all about how to create PDF document in the created event of Syncfusion&reg; Blazor PDF Viewer component and more.
+title: Create PDF document in the PDF Viewer created event | Syncfusion
+description: Learn here all about how to create PDF document in the created event of Syncfusion Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/create-pdf-viewer.md
+++ b/blazor/pdfviewer/how-to/create-pdf-viewer.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: View the created PDF document | Syncfusion®
-description: Learn here all about View the created PDF document in Syncfusion® Blazor PDF Viewer component and more.
+title: View the created PDF document | Syncfusion&reg;
+description: Learn here all about View the created PDF document in Syncfusion&reg; Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
@@ -9,7 +9,7 @@ documentation: ug
 
 # View the created PDF document
 
-The Syncfusion®'s Blazor PDF Viewer component allows you to view the created PDF document using the [**Created**](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.PdfViewer.PdfViewerEvents.html#Syncfusion_Blazor_PdfViewer_PdfViewerEvents_Created) event.
+The Syncfusion&reg; Blazor PDF Viewer component allows you to view the created PDF document using the [**Created**](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.PdfViewer.PdfViewerEvents.html#Syncfusion_Blazor_PdfViewer_PdfViewerEvents_Created) event.
 
 The following code example shows how to view the created PDF document.
 

--- a/blazor/pdfviewer/how-to/create-pdf-viewer.md
+++ b/blazor/pdfviewer/how-to/create-pdf-viewer.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: View the created PDF document | Syncfusion&reg;
-description: Learn here all about View the created PDF document in Syncfusion&reg; Blazor PDF Viewer component and more.
+title: View the created PDF document | Syncfusion
+description: Learn here all about View the created PDF document in Syncfusion Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/create-pdfviewer-in-a-popup-window.md
+++ b/blazor/pdfviewer/how-to/create-pdfviewer-in-a-popup-window.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Create PDF Viewer in a popup window in Blazor PDF Viewer | Syncfusion&reg;
-description: Learn here all about Create PDF Viewer in a popup window in Syncfusion&reg; Blazor PDF Viewer component and more.
+title: Create PDF Viewer in a popup window in Blazor PDF Viewer | Syncfusion
+description: Learn here all about Create PDF Viewer in a popup window in Syncfusion Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/create-pdfviewer-in-a-popup-window.md
+++ b/blazor/pdfviewer/how-to/create-pdfviewer-in-a-popup-window.md
@@ -9,7 +9,7 @@ documentation: ug
 
 # Create PDF Viewer in a popup window in Blazor PDF Viewer Component
 
-For quick view, you might need to display the PDF file in a dialog window. The following code snippet explains how to use the PDF Viewer component inside a dialog window. In this example, the Syncfusion&reg;’s dialog component is used for Blazor.
+For quick view, you might need to display the PDF file in a dialog window. The following code snippet explains how to use the PDF Viewer component inside a dialog window. In this example, the Syncfusion&reg; dialog component is used for Blazor.
 
 ```cshtml
 @using Syncfusion.Blazor.Buttons

--- a/blazor/pdfviewer/how-to/create-pdfviewer-in-a-popup-window.md
+++ b/blazor/pdfviewer/how-to/create-pdfviewer-in-a-popup-window.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Create PDF Viewer in a popup window in Blazor PDF Viewer | Syncfusion®
-description: Learn here all about Create PDF Viewer in a popup window in Syncfusion® Blazor PDF Viewer component and more.
+title: Create PDF Viewer in a popup window in Blazor PDF Viewer | Syncfusion&reg;
+description: Learn here all about Create PDF Viewer in a popup window in Syncfusion&reg; Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
@@ -9,7 +9,7 @@ documentation: ug
 
 # Create PDF Viewer in a popup window in Blazor PDF Viewer Component
 
-For quick view, you might need to display the PDF file in a dialog window. The following code snippet explains how to use the PDF Viewer component inside a dialog window. In this example, the Syncfusion®’s dialog component is used for Blazor.
+For quick view, you might need to display the PDF file in a dialog window. The following code snippet explains how to use the PDF Viewer component inside a dialog window. In this example, the Syncfusion&reg;’s dialog component is used for Blazor.
 
 ```cshtml
 @using Syncfusion.Blazor.Buttons

--- a/blazor/pdfviewer/how-to/create-pdfviewer-in-a-splitter-component.md
+++ b/blazor/pdfviewer/how-to/create-pdfviewer-in-a-splitter-component.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Create PDF Viewer in a Splitter Component in Blazor | Syncfusion&reg;
-description: Learn here all about how to create PDF Viewer in a Splitter Component in Syncfusion&reg; Blazor PDF Viewer component.
+title: Create PDF Viewer in a Splitter Component in Blazor | Syncfusion
+description: Learn here all about how to create PDF Viewer in a Splitter Component in Syncfusion Blazor PDF Viewer component.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/create-pdfviewer-in-a-splitter-component.md
+++ b/blazor/pdfviewer/how-to/create-pdfviewer-in-a-splitter-component.md
@@ -9,7 +9,7 @@ documentation: ug
 
 # Create PDF Viewer in Splitter Component in Blazor PDF Viewer Component
 
-You can use Splitter to render the PDF Viewer while rendering more than one component. The following code snippet explains how to render the PDF Viewer component inside a Splitter pane. In this example, the Syncfusion&reg;’s Splitter component is used to render PDF Viewer.
+You can use Splitter to render the PDF Viewer while rendering more than one component. The following code snippet explains how to render the PDF Viewer component inside a Splitter pane. In this example, the Syncfusion&reg; Splitter component is used to render PDF Viewer.
 
 ```cshtml
 @using Syncfusion.Blazor.PdfViewerServer

--- a/blazor/pdfviewer/how-to/create-pdfviewer-in-a-splitter-component.md
+++ b/blazor/pdfviewer/how-to/create-pdfviewer-in-a-splitter-component.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Create PDF Viewer in a Splitter Component in Blazor | Syncfusion®
-description: Learn here all about how to create PDF Viewer in a Splitter Component in Syncfusion® Blazor PDF Viewer component.
+title: Create PDF Viewer in a Splitter Component in Blazor | Syncfusion&reg;
+description: Learn here all about how to create PDF Viewer in a Splitter Component in Syncfusion&reg; Blazor PDF Viewer component.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
@@ -9,7 +9,7 @@ documentation: ug
 
 # Create PDF Viewer in Splitter Component in Blazor PDF Viewer Component
 
-You can use Splitter to render the PDF Viewer while rendering more than one component. The following code snippet explains how to render the PDF Viewer component inside a Splitter pane. In this example, the Syncfusion®’s Splitter component is used to render PDF Viewer.
+You can use Splitter to render the PDF Viewer while rendering more than one component. The following code snippet explains how to render the PDF Viewer component inside a Splitter pane. In this example, the Syncfusion&reg;’s Splitter component is used to render PDF Viewer.
 
 ```cshtml
 @using Syncfusion.Blazor.PdfViewerServer

--- a/blazor/pdfviewer/how-to/customize-arrow-annotation-heads.md
+++ b/blazor/pdfviewer/how-to/customize-arrow-annotation-heads.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Customize the arrow annotation heads in Blazor PDF Viewer | Syncfusion®
-description: Learn here all about how to increase the connection buffer size in Syncfusion® Blazor PDF Viewer component and more.
+title: Customize the arrow annotation heads in Blazor PDF Viewer | Syncfusion&reg;
+description: Learn here all about how to increase the connection buffer size in Syncfusion&reg; Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/customize-arrow-annotation-heads.md
+++ b/blazor/pdfviewer/how-to/customize-arrow-annotation-heads.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Customize the arrow annotation heads in Blazor PDF Viewer | Syncfusion&reg;
-description: Learn here all about how to increase the connection buffer size in Syncfusion&reg; Blazor PDF Viewer component and more.
+title: Customize the arrow annotation heads in Blazor PDF Viewer | Syncfusion
+description: Learn here all about how to increase the connection buffer size in Syncfusion Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/get-data-from-pdf-viewer.md
+++ b/blazor/pdfviewer/how-to/get-data-from-pdf-viewer.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Get loaded PDF document's data from Blazor PDF Viewer | Syncfusion®
-description: Learn here all about how to get loaded PDF document's data in Syncfusion® Blazor PDF Viewer component and more.
+title: Get loaded PDF document's data from Blazor PDF Viewer | Syncfusion&reg;
+description: Learn here all about how to get loaded PDF document's data in Syncfusion&reg; Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/get-data-from-pdf-viewer.md
+++ b/blazor/pdfviewer/how-to/get-data-from-pdf-viewer.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Get loaded PDF document's data from Blazor PDF Viewer | Syncfusion&reg;
-description: Learn here all about how to get loaded PDF document's data in Syncfusion&reg; Blazor PDF Viewer component and more.
+title: Get loaded PDF document's data from Blazor PDF Viewer | Syncfusion
+description: Learn here all about how to get loaded PDF document's data in Syncfusion Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/identify-the-values-in-the-undo-redo-collections.md
+++ b/blazor/pdfviewer/how-to/identify-the-values-in-the-undo-redo-collections.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Identify if the Viewer has values in the Undo, Redo stack | Syncfusion&reg;
-description: Learn how to identify if the Viewer has values in Undo, Redo stack in Syncfusion&reg; Blazor PDF Viewer component and more.
+title: Identify if the Viewer has values in the Undo, Redo stack | Syncfusion
+description: Learn how to identify if the Viewer has values in Undo, Redo stack in Syncfusion Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/identify-the-values-in-the-undo-redo-collections.md
+++ b/blazor/pdfviewer/how-to/identify-the-values-in-the-undo-redo-collections.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Identify if the Viewer has values in the Undo, Redo stack | Syncfusion®
-description: Learn how to identify if the Viewer has values in Undo, Redo stack in Syncfusion® Blazor PDF Viewer component and more.
+title: Identify if the Viewer has values in the Undo, Redo stack | Syncfusion&reg;
+description: Learn how to identify if the Viewer has values in Undo, Redo stack in Syncfusion&reg; Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
@@ -9,7 +9,7 @@ documentation: ug
 
 # Identify if the PDF Viewer has values in the Undo, Redo collections
 
-Syncfusion®'s Blazor PDF Viewer component allows you to identify if the PDF Viewer has values in the Undo and Redo collections using the `CanUndo` and `CanRedo` APIs of the PDF Viewer.
+Syncfusion&reg; Blazor PDF Viewer component allows you to identify if the PDF Viewer has values in the Undo and Redo collections using the `CanUndo` and `CanRedo` APIs of the PDF Viewer.
 
 The following code example shows how to achieve this based on the Undo Redo actions.
 

--- a/blazor/pdfviewer/how-to/import-annotations-as-objects.md
+++ b/blazor/pdfviewer/how-to/import-annotations-as-objects.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Import annotations as objects in Blazor PDF Viewer | Syncfusion®
-description: Learn here all about Import annotations as objects in Syncfusion® Blazor PDF Viewer component and more.
+title: Import annotations as objects in Blazor PDF Viewer | Syncfusion&reg;
+description: Learn here all about Import annotations as objects in Syncfusion&reg; Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
@@ -9,7 +9,7 @@ documentation: ug
 
 # Import annotations as objects in Blazor PDF Viewer Component
 
-The Syncfusion®'s Blazor PDF Viewer component allows to import annotations from objects or streams instead of loading it as a file. To import such annotation objects, the PDF Viewer control must export the PDF annotations as objects using the [ExportAnnotationsAsObject()](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.PdfViewer.PdfViewerBase.html#Syncfusion_Blazor_PdfViewer_PdfViewerBase_ExportAnnotationsAsObject) method. Only the annotations objects that are exported from the PDF Viewer can be imported.
+The Syncfusion&reg; Blazor PDF Viewer component allows to import annotations from objects or streams instead of loading it as a file. To import such annotation objects, the PDF Viewer control must export the PDF annotations as objects using the [ExportAnnotationsAsObject()](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.PdfViewer.PdfViewerBase.html#Syncfusion_Blazor_PdfViewer_PdfViewerBase_ExportAnnotationsAsObject) method. Only the annotations objects that are exported from the PDF Viewer can be imported.
 
 The following code example shows how to import annotations as objects, that are exported using the [ExportAnnotationsAsObject()](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.PdfViewer.PdfViewerBase.html#Syncfusion_Blazor_PdfViewer_PdfViewerBase_ExportAnnotationsAsObject) method.
 

--- a/blazor/pdfviewer/how-to/import-annotations-as-objects.md
+++ b/blazor/pdfviewer/how-to/import-annotations-as-objects.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Import annotations as objects in Blazor PDF Viewer | Syncfusion&reg;
-description: Learn here all about Import annotations as objects in Syncfusion&reg; Blazor PDF Viewer component and more.
+title: Import annotations as objects in Blazor PDF Viewer | Syncfusion
+description: Learn here all about Import annotations as objects in Syncfusion Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/increase-connection-buffer-size.md
+++ b/blazor/pdfviewer/how-to/increase-connection-buffer-size.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Increase the connection buffer size in Blazor PDF Viewer | Syncfusion&reg;
-description: Learn here all about how to increase the connection buffer size in Syncfusion&reg; Blazor PDF Viewer component and more.
+title: Increase the connection buffer size in Blazor PDF Viewer | Syncfusion
+description: Learn here all about how to increase the connection buffer size in Syncfusion Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/increase-connection-buffer-size.md
+++ b/blazor/pdfviewer/how-to/increase-connection-buffer-size.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Increase the connection buffer size in Blazor PDF Viewer | Syncfusion®
-description: Learn here all about how to increase the connection buffer size in Syncfusion® Blazor PDF Viewer component and more.
+title: Increase the connection buffer size in Blazor PDF Viewer | Syncfusion&reg;
+description: Learn here all about how to increase the connection buffer size in Syncfusion&reg; Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
@@ -9,7 +9,7 @@ documentation: ug
 
 # Increase the connection buffer size in Blazor PDF Viewer Component
 
-The Syncfusion®'s Blazor PDF Viewer component allows to increase the connection buffer size by adding the below service in program.cs file if the size of the PDFViewer is too large.
+The Syncfusion&reg; Blazor PDF Viewer component allows to increase the connection buffer size by adding the below service in program.cs file if the size of the PDFViewer is too large.
 
 ```cshtml
 builder.Services.AddServerSideBlazor().AddHubOptions(o => { o.MaximumReceiveMessageSize = 102400000; });

--- a/blazor/pdfviewer/how-to/load-desired-pdf-for-initial-loading-in-hosted-sample.md
+++ b/blazor/pdfviewer/how-to/load-desired-pdf-for-initial-loading-in-hosted-sample.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Load desired PDF for initial loading in Blazor PDF Viewer | Syncfusion®
-description: Learn here all about how to load desired PDF for initial loading in Syncfusion® Blazor PDF Viewer component and more.
+title: Load desired PDF for initial loading in Blazor PDF Viewer | Syncfusion&reg;
+description: Learn here all about how to load desired PDF for initial loading in Syncfusion&reg; Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/load-desired-pdf-for-initial-loading-in-hosted-sample.md
+++ b/blazor/pdfviewer/how-to/load-desired-pdf-for-initial-loading-in-hosted-sample.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Load desired PDF for initial loading in Blazor PDF Viewer | Syncfusion&reg;
-description: Learn here all about how to load desired PDF for initial loading in Syncfusion&reg; Blazor PDF Viewer component and more.
+title: Load desired PDF for initial loading in Blazor PDF Viewer | Syncfusion
+description: Learn here all about how to load desired PDF for initial loading in Syncfusion Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/load-office-files.md
+++ b/blazor/pdfviewer/how-to/load-office-files.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Load office files in Blazor PDF Viewer | Syncfusion®
-description: Learn here all about how to load the microsoft office files like powerpoint in the Syncfusion® Blazor PDF Viewer component and more.
+title: Load office files in Blazor PDF Viewer | Syncfusion&reg;
+description: Learn here all about how to load the microsoft office files like powerpoint in the Syncfusion&reg; Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/load-office-files.md
+++ b/blazor/pdfviewer/how-to/load-office-files.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Load office files in Blazor PDF Viewer | Syncfusion&reg;
-description: Learn here all about how to load the microsoft office files like powerpoint in the Syncfusion&reg; Blazor PDF Viewer component and more.
+title: Load office files in Blazor PDF Viewer | Syncfusion
+description: Learn here all about how to load the microsoft office files like powerpoint in the Syncfusion Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/load-pdf-document-dynamically.md
+++ b/blazor/pdfviewer/how-to/load-pdf-document-dynamically.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Load PDF documents dynamically in Blazor PDF Viewer | Syncfusion&reg;
-description: Learn here all about how to load PDF documents dynamically in Syncfusion&reg; Blazor PDF Viewer component and more.
+title: Load PDF documents dynamically in Blazor PDF Viewer | Syncfusion
+description: Learn here all about how to load PDF documents dynamically in Syncfusion Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/load-pdf-document-dynamically.md
+++ b/blazor/pdfviewer/how-to/load-pdf-document-dynamically.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Load PDF documents dynamically in Blazor PDF Viewer | Syncfusion®
-description: Learn here all about how to load PDF documents dynamically in Syncfusion® Blazor PDF Viewer component and more.
+title: Load PDF documents dynamically in Blazor PDF Viewer | Syncfusion&reg;
+description: Learn here all about how to load PDF documents dynamically in Syncfusion&reg; Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/move-scrollbar.md
+++ b/blazor/pdfviewer/how-to/move-scrollbar.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Move the scrollbar to the exact location of annotations | Syncfusion&reg;
-description: Learn here all about move scrollbar to the exact location of annotations in Syncfusion&reg; Blazor PDF Viewer component and more.
+title: Move the scrollbar to the exact location of annotations | Syncfusion
+description: Learn here all about move scrollbar to the exact location of annotations in Syncfusion Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/move-scrollbar.md
+++ b/blazor/pdfviewer/how-to/move-scrollbar.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Move the scrollbar to the exact location of annotations | Syncfusion®
-description: Learn here all about move scrollbar to the exact location of annotations in Syncfusion® Blazor PDF Viewer component and more.
+title: Move the scrollbar to the exact location of annotations | Syncfusion&reg;
+description: Learn here all about move scrollbar to the exact location of annotations in Syncfusion&reg; Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
@@ -9,7 +9,7 @@ documentation: ug
 
 # Move the scrollbar to the exact location of annotations
 
-The Syncfusion®'s Blazor PDF Viewer component allows you to move the scrollbar to the exact location of annotations present in a loaded PDF document using the **GoToBookmark** method.
+The Syncfusion&reg; Blazor PDF Viewer component allows you to move the scrollbar to the exact location of annotations present in a loaded PDF document using the **GoToBookmark** method.
 
 The following code example shows how to move the scrollbar to annotation location.
 

--- a/blazor/pdfviewer/how-to/prevent-scrolling.md
+++ b/blazor/pdfviewer/how-to/prevent-scrolling.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Prevent the PDF from scrolling | Syncfusion&reg;
-description: Learn here all about Create PDF Viewer in a popup window in Syncfusion&reg; Blazor PDF Viewer component and more.
+title: Prevent the PDF from scrolling | Syncfusion
+description: Learn here all about Create PDF Viewer in a popup window in Syncfusion Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/prevent-scrolling.md
+++ b/blazor/pdfviewer/how-to/prevent-scrolling.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Prevent the PDF from scrolling | Syncfusion®
-description: Learn here all about Create PDF Viewer in a popup window in Syncfusion® Blazor PDF Viewer component and more.
+title: Prevent the PDF from scrolling | Syncfusion&reg;
+description: Learn here all about Create PDF Viewer in a popup window in Syncfusion&reg; Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
@@ -9,7 +9,7 @@ documentation: ug
 
 # Prevent the PDF from scrolling and remove the vertical scrollbar
 
-To prevent a PDF from scrolling and remove the vertical scroll bar in the Syncfusion® Blazor PDF Viewer component, use CSS to set the `overflow` property of the component container to `hidden`.
+To prevent a PDF from scrolling and remove the vertical scroll bar in the Syncfusion&reg; Blazor PDF Viewer component, use CSS to set the `overflow` property of the component container to `hidden`.
 
 By setting the overflow property to hidden, the PDF viewer component will be displayed without a vertical scrollbar, and the user will not be able to scroll the content of a PDF.
 

--- a/blazor/pdfviewer/how-to/print-the-PDFViewer-inside-the-Dialog-component.md
+++ b/blazor/pdfviewer/how-to/print-the-PDFViewer-inside-the-Dialog-component.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Print the PDFViewer inside the Dialog in Blazor | Syncfusion&reg;
-description: Learn here all about how to print the PDFViewer inside the Dialog in Syncfusion&reg; Blazor PDF Viewer component and more.
+title: Print the PDFViewer inside the Dialog in Blazor | Syncfusion
+description: Learn here all about how to print the PDFViewer inside the Dialog in Syncfusion Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/print-the-PDFViewer-inside-the-Dialog-component.md
+++ b/blazor/pdfviewer/how-to/print-the-PDFViewer-inside-the-Dialog-component.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Print the PDFViewer inside the Dialog in Blazor | Syncfusion®
-description: Learn here all about how to print the PDFViewer inside the Dialog in Syncfusion® Blazor PDF Viewer component and more.
+title: Print the PDFViewer inside the Dialog in Blazor | Syncfusion&reg;
+description: Learn here all about how to print the PDFViewer inside the Dialog in Syncfusion&reg; Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/render-ej2-pdf-viewer-in-blazor.md
+++ b/blazor/pdfviewer/how-to/render-ej2-pdf-viewer-in-blazor.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Render JS PDF Viewer in Blazor | Syncfusion®
-description: Learn here all about how to render the JS PDF Viewer in Syncfusion® Blazor PDF Viewer component and more.
+title: Render JS PDF Viewer in Blazor | Syncfusion&reg;
+description: Learn here all about how to render the JS PDF Viewer in Syncfusion&reg; Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
@@ -9,7 +9,7 @@ documentation: ug
 
 # Render JS PDF Viewer inside Blazor component
 
-The Syncfusion®'s Blazor PDF Viewer component allows you to render the JS PDF Viewer component inside the blazor component.
+The Syncfusion&reg; Blazor PDF Viewer component allows you to render the JS PDF Viewer component inside the blazor component.
 
 The following code example shows how to render the JS PDF Viewer component into the blazor component.
 

--- a/blazor/pdfviewer/how-to/render-ej2-pdf-viewer-in-blazor.md
+++ b/blazor/pdfviewer/how-to/render-ej2-pdf-viewer-in-blazor.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Render JS PDF Viewer in Blazor | Syncfusion&reg;
-description: Learn here all about how to render the JS PDF Viewer in Syncfusion&reg; Blazor PDF Viewer component and more.
+title: Render JS PDF Viewer in Blazor | Syncfusion
+description: Learn here all about how to render the JS PDF Viewer in Syncfusion Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/resolve-System-EntryPointNotFound-exception.md
+++ b/blazor/pdfviewer/how-to/resolve-System-EntryPointNotFound-exception.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Resolve System.EntryPointNotFound exception in PDF Viewer | Syncfusion&reg;
-description: Learn here all about how to solve EntryPointNotFound exception in Syncfusion&reg; Blazor PDF Viewer component and more.
+title: Resolve System.EntryPointNotFound exception in PDF Viewer | Syncfusion
+description: Learn here all about how to solve EntryPointNotFound exception in Syncfusion Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/resolve-System-EntryPointNotFound-exception.md
+++ b/blazor/pdfviewer/how-to/resolve-System-EntryPointNotFound-exception.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Resolve System.EntryPointNotFound exception in PDF Viewer | Syncfusion®
-description: Learn here all about how to solve EntryPointNotFound exception in Syncfusion® Blazor PDF Viewer component and more.
+title: Resolve System.EntryPointNotFound exception in PDF Viewer | Syncfusion&reg;
+description: Learn here all about how to solve EntryPointNotFound exception in Syncfusion&reg; Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
@@ -9,7 +9,7 @@ documentation: ug
 
 # Resolve System.EntryPointNotFound exception in Blazor PdfViewer
 
-From the release of version **21.1.0.35 (2023 Volume 1)** of Essential Studio®, the Pdfium package has been upgraded to improve various functionalities like text search, text selection, rendering, and even performance. If you are updating your project to this version of the Syncfusion® PDF Viewer, you may encounter the **“System.EntryPointNotFoundException”** error in the output window. Moreover, the spinner keeps spinning without loading any document on server projects. This is typically caused by an old version of the pdfium assembly being referenced in the local web service project. Below are the assemblies to be referred to in the respective operating systems.
+From the release of version **21.1.0.35 (2023 Volume 1)** of Essential Studio&reg;, the Pdfium package has been upgraded to improve various functionalities like text search, text selection, rendering, and even performance. If you are updating your project to this version of the Syncfusion&reg; PDF Viewer, you may encounter the **“System.EntryPointNotFoundException”** error in the output window. Moreover, the spinner keeps spinning without loading any document on server projects. This is typically caused by an old version of the pdfium assembly being referenced in the local web service project. Below are the assemblies to be referred to in the respective operating systems.
 
 * Windows – pdfium.dll
 * Linux – libpdfium.so

--- a/blazor/pdfviewer/how-to/show-or-hide-pdfviewer-dynamically.md
+++ b/blazor/pdfviewer/how-to/show-or-hide-pdfviewer-dynamically.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Show or hide the pdfviewer dynamically in Blazor | Syncfusion&reg;
-description: Learn here all about how to show or hide the pdfviewer dynamically in Syncfusion&reg; Blazor PDF Viewer component and more.
+title: Show or hide the pdfviewer dynamically in Blazor | Syncfusion
+description: Learn here all about how to show or hide the pdfviewer dynamically in Syncfusion Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/show-or-hide-pdfviewer-dynamically.md
+++ b/blazor/pdfviewer/how-to/show-or-hide-pdfviewer-dynamically.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Show or hide the pdfviewer dynamically in Blazor | Syncfusion®
-description: Learn here all about how to show or hide the pdfviewer dynamically in Syncfusion® Blazor PDF Viewer component and more.
+title: Show or hide the pdfviewer dynamically in Blazor | Syncfusion&reg;
+description: Learn here all about how to show or hide the pdfviewer dynamically in Syncfusion&reg; Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/stretch-the-pdf-viewer-size-to-its-container.md
+++ b/blazor/pdfviewer/how-to/stretch-the-pdf-viewer-size-to-its-container.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Update the PDF Viewer size to its container in PDF Viewer | Syncfusion&reg;
-description: Learn here all about how to stretch the PDF Viewer size to its container in Syncfusion&reg; Blazor PDF Viewer component.
+title: Update the PDF Viewer size to its container in PDF Viewer | Syncfusion
+description: Learn here all about how to stretch the PDF Viewer size to its container in Syncfusion Blazor PDF Viewer component.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/stretch-the-pdf-viewer-size-to-its-container.md
+++ b/blazor/pdfviewer/how-to/stretch-the-pdf-viewer-size-to-its-container.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Update the PDF Viewer size to its container in PDF Viewer | Syncfusion®
-description: Learn here all about how to stretch the PDF Viewer size to its container in Syncfusion® Blazor PDF Viewer component.
+title: Update the PDF Viewer size to its container in PDF Viewer | Syncfusion&reg;
+description: Learn here all about how to stretch the PDF Viewer size to its container in Syncfusion&reg; Blazor PDF Viewer component.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
@@ -9,7 +9,7 @@ documentation: ug
 
 # Update PDF Viewer size at run-time in Blazor PDF Viewer Component
 
-You can stretch the PDF Viewer size to its container size while resizing the container at runtime. The following code snippet explains how to update the PDF Viewer size while resizing the Splitter at runtime. In this example, the Syncfusion®’s Splitter component is used.
+You can stretch the PDF Viewer size to its container size while resizing the container at runtime. The following code snippet explains how to update the PDF Viewer size while resizing the Splitter at runtime. In this example, the Syncfusion&reg;’s Splitter component is used.
 
 ```cshtml
 @using Syncfusion.Blazor.PdfViewer

--- a/blazor/pdfviewer/how-to/stretch-the-pdf-viewer-size-to-its-container.md
+++ b/blazor/pdfviewer/how-to/stretch-the-pdf-viewer-size-to-its-container.md
@@ -9,7 +9,7 @@ documentation: ug
 
 # Update PDF Viewer size at run-time in Blazor PDF Viewer Component
 
-You can stretch the PDF Viewer size to its container size while resizing the container at runtime. The following code snippet explains how to update the PDF Viewer size while resizing the Splitter at runtime. In this example, the Syncfusion&reg;’s Splitter component is used.
+You can stretch the PDF Viewer size to its container size while resizing the container at runtime. The following code snippet explains how to update the PDF Viewer size while resizing the Splitter at runtime. In this example, the Syncfusion&reg; Splitter component is used.
 
 ```cshtml
 @using Syncfusion.Blazor.PdfViewer

--- a/blazor/pdfviewer/how-to/suppress-error-message.md
+++ b/blazor/pdfviewer/how-to/suppress-error-message.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Suppress the error dialog in the Blazor PDF Viewer | Syncfusion®
-description: Learn here all about how to suppress the error dialog in Syncfusion® Blazor PDF Viewer component and more.
+title: Suppress the error dialog in the Blazor PDF Viewer | Syncfusion&reg;
+description: Learn here all about how to suppress the error dialog in Syncfusion&reg; Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
@@ -9,7 +9,7 @@ documentation: ug
 
 # Suppress the error dialog in Blazor PDF Viewer Component
 
-The Syncfusion®'s Blazor PDF Viewer component allows you to suppress or disable the error dialog box displayed in the PDF Viewer using the [**EnableErrorDialog**](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.PdfViewer.PdfViewerBase.html#Syncfusion_Blazor_PdfViewer_PdfViewerBase_EnableErrorDialog) property. The default value of the property is `true`.
+The Syncfusion&reg; Blazor PDF Viewer component allows you to suppress or disable the error dialog box displayed in the PDF Viewer using the [**EnableErrorDialog**](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.PdfViewer.PdfViewerBase.html#Syncfusion_Blazor_PdfViewer_PdfViewerBase_EnableErrorDialog) property. The default value of the property is `true`.
 
 The following code example shows how to suppress the error dialog.
 

--- a/blazor/pdfviewer/how-to/suppress-error-message.md
+++ b/blazor/pdfviewer/how-to/suppress-error-message.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Suppress the error dialog in the Blazor PDF Viewer | Syncfusion&reg;
-description: Learn here all about how to suppress the error dialog in Syncfusion&reg; Blazor PDF Viewer component and more.
+title: Suppress the error dialog in the Blazor PDF Viewer | Syncfusion
+description: Learn here all about how to suppress the error dialog in Syncfusion Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/unexpected-token.md
+++ b/blazor/pdfviewer/how-to/unexpected-token.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Resolve the "Unexpected token T in JSON at position 0" | Syncfusion®
-description: Learn here all about resolve the "Unexpected token T in JSON at position 0" error in the LINUX platform in Syncfusion® Blazor PDF Viewer component and more.
+title: Resolve the "Unexpected token T in JSON at position 0" | Syncfusion&reg;
+description: Learn here all about resolve the "Unexpected token T in JSON at position 0" error in the LINUX platform in Syncfusion&reg; Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/unexpected-token.md
+++ b/blazor/pdfviewer/how-to/unexpected-token.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Resolve the "Unexpected token T in JSON at position 0" | Syncfusion&reg;
-description: Learn here all about resolve the "Unexpected token T in JSON at position 0" error in the LINUX platform in Syncfusion&reg; Blazor PDF Viewer component and more.
+title: Resolve the "Unexpected token T in JSON at position 0" | Syncfusion
+description: Learn here all about resolve the "Unexpected token T in JSON at position 0" error in the LINUX platform in Syncfusion Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/unload-the-pdf-document-from-viewer.md
+++ b/blazor/pdfviewer/how-to/unload-the-pdf-document-from-viewer.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Unload the PDF document from Viewer in Blazor PDF Viewer | Syncfusion®
-description: Learn here all about Unload the PDF document from Viewer in Syncfusion® Blazor PDF Viewer component and more.
+title: Unload the PDF document from Viewer in Blazor PDF Viewer | Syncfusion&reg;
+description: Learn here all about Unload the PDF document from Viewer in Syncfusion&reg; Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/unload-the-pdf-document-from-viewer.md
+++ b/blazor/pdfviewer/how-to/unload-the-pdf-document-from-viewer.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Unload the PDF document from Viewer in Blazor PDF Viewer | Syncfusion&reg;
-description: Learn here all about Unload the PDF document from Viewer in Syncfusion&reg; Blazor PDF Viewer component and more.
+title: Unload the PDF document from Viewer in Blazor PDF Viewer | Syncfusion
+description: Learn here all about Unload the PDF document from Viewer in Syncfusion Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/update-form-field-using-context-menu.md
+++ b/blazor/pdfviewer/how-to/update-form-field-using-context-menu.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Update form field using context menu in Blazor PDF Viewer | Syncfusion®
-description: Learn here all about how to update form field using context menu in Syncfusion® Blazor PDF Viewer component and more.
+title: Update form field using context menu in Blazor PDF Viewer | Syncfusion&reg;
+description: Learn here all about how to update form field using context menu in Syncfusion&reg; Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
@@ -9,7 +9,7 @@ documentation: ug
 
 # Update form field using context menu in Blazor PDF Viewer Component
 
-You can update the form field's at runtime using the FormFieldClick event and UpdateFormFieldsAsync() method of PDF Viewer. The following code example explains how to open Context menu when you click on the form field and how to update the menu item content as form field's value. In this example, the Syncfusion®’s ContextMenu component is used to update form field.
+You can update the form field's at runtime using the FormFieldClick event and UpdateFormFieldsAsync() method of PDF Viewer. The following code example explains how to open Context menu when you click on the form field and how to update the menu item content as form field's value. In this example, the Syncfusion&reg;’s ContextMenu component is used to update form field.
 
 
 ```cshtml

--- a/blazor/pdfviewer/how-to/update-form-field-using-context-menu.md
+++ b/blazor/pdfviewer/how-to/update-form-field-using-context-menu.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Update form field using context menu in Blazor PDF Viewer | Syncfusion&reg;
-description: Learn here all about how to update form field using context menu in Syncfusion&reg; Blazor PDF Viewer component and more.
+title: Update form field using context menu in Blazor PDF Viewer | Syncfusion
+description: Learn here all about how to update form field using context menu in Syncfusion Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/update-form-field-using-context-menu.md
+++ b/blazor/pdfviewer/how-to/update-form-field-using-context-menu.md
@@ -9,7 +9,7 @@ documentation: ug
 
 # Update form field using context menu in Blazor PDF Viewer Component
 
-You can update the form field's at runtime using the FormFieldClick event and UpdateFormFieldsAsync() method of PDF Viewer. The following code example explains how to open Context menu when you click on the form field and how to update the menu item content as form field's value. In this example, the Syncfusion&reg;’s ContextMenu component is used to update form field.
+You can update the form field's at runtime using the FormFieldClick event and UpdateFormFieldsAsync() method of PDF Viewer. The following code example explains how to open Context menu when you click on the form field and how to update the menu item content as form field's value. In this example, the Syncfusion&reg; ContextMenu component is used to update form field.
 
 
 ```cshtml

--- a/blazor/pdfviewer/how-to/view-docx-file-in-blazor-application.md
+++ b/blazor/pdfviewer/how-to/view-docx-file-in-blazor-application.md
@@ -13,12 +13,12 @@ You can achieve this requirement of viewing DOCX file in two ways:.
 
 **Option** **1:**
 
-You can use Syncfusion&reg;’s Word Processor component for Blazor to compose, view, and edit DOC, DOCX, RTF, and SFDT file formats.
+You can use Syncfusion&reg; Word Processor component for Blazor to compose, view, and edit DOC, DOCX, RTF, and SFDT file formats.
 
 To learn more about the [Word Processor component](https://www.syncfusion.com/blazor-components/blazor-word-processor), check out Syncfusion&reg; online samples and documentation.
 
 **Option** **2:**
 
-You can convert [Word document to PDF](https://help.syncfusion.com/file-formats/docio/word-to-pdf) using the Syncfusion&reg;’s Word (DocIO) server-side library and view the resultant PDF file using PDF Viewer component.
+You can convert [Word document to PDF](https://help.syncfusion.com/file-formats/docio/word-to-pdf) using the Syncfusion&reg; Word (DocIO) server-side library and view the resultant PDF file using PDF Viewer component.
 
 N> You can refer to our [Blazor PDF Viewer](https://www.syncfusion.com/blazor-components/blazor-pdf-viewer) feature tour page for its groundbreaking feature representations. You can also explore our [Blazor PDF Viewer example](https://blazor.syncfusion.com/demos/pdf-viewer/default-functionalities?theme=bootstrap4) to understand how to explains core features of PDF Viewer.

--- a/blazor/pdfviewer/how-to/view-docx-file-in-blazor-application.md
+++ b/blazor/pdfviewer/how-to/view-docx-file-in-blazor-application.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: View DOCX file in Blazor application using PDF Viewer | Syncfusion&reg;
-description: Learn here all about View DOCX file in Blazor application in Syncfusion&reg; Blazor PDF Viewer component and more.
+title: View DOCX file in Blazor application using PDF Viewer | Syncfusion
+description: Learn here all about View DOCX file in Blazor application in Syncfusion Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/how-to/view-docx-file-in-blazor-application.md
+++ b/blazor/pdfviewer/how-to/view-docx-file-in-blazor-application.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: View DOCX file in Blazor application using PDF Viewer | Syncfusion®
-description: Learn here all about View DOCX file in Blazor application in Syncfusion® Blazor PDF Viewer component and more.
+title: View DOCX file in Blazor application using PDF Viewer | Syncfusion&reg;
+description: Learn here all about View DOCX file in Blazor application in Syncfusion&reg; Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
@@ -13,12 +13,12 @@ You can achieve this requirement of viewing DOCX file in two ways:.
 
 **Option** **1:**
 
-You can use Syncfusion®’s Word Processor component for Blazor to compose, view, and edit DOC, DOCX, RTF, and SFDT file formats.
+You can use Syncfusion&reg;’s Word Processor component for Blazor to compose, view, and edit DOC, DOCX, RTF, and SFDT file formats.
 
-To learn more about the [Word Processor component](https://www.syncfusion.com/blazor-components/blazor-word-processor), check out Syncfusion® online samples and documentation.
+To learn more about the [Word Processor component](https://www.syncfusion.com/blazor-components/blazor-word-processor), check out Syncfusion&reg; online samples and documentation.
 
 **Option** **2:**
 
-You can convert [Word document to PDF](https://help.syncfusion.com/file-formats/docio/word-to-pdf) using the Syncfusion®’s Word (DocIO) server-side library and view the resultant PDF file using PDF Viewer component.
+You can convert [Word document to PDF](https://help.syncfusion.com/file-formats/docio/word-to-pdf) using the Syncfusion&reg;’s Word (DocIO) server-side library and view the resultant PDF file using PDF Viewer component.
 
 N> You can refer to our [Blazor PDF Viewer](https://www.syncfusion.com/blazor-components/blazor-pdf-viewer) feature tour page for its groundbreaking feature representations. You can also explore our [Blazor PDF Viewer example](https://blazor.syncfusion.com/demos/pdf-viewer/default-functionalities?theme=bootstrap4) to understand how to explains core features of PDF Viewer.

--- a/blazor/pdfviewer/how-to/webservice-not-listening.md
+++ b/blazor/pdfviewer/how-to/webservice-not-listening.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: How to clear the "Web-service is not listening" to error| Syncfusion®
-description: Learn here all about How to clear the "Web-service is not listening" to error in Syncfusion® React Pdfviewer component of Syncfusion® Essential® JS 2 and more.
+title: How to clear the "Web-service is not listening" to error| Syncfusion&reg;
+description: Learn here all about How to clear the "Web-service is not listening" to error in Syncfusion&reg; React Pdfviewer component of Syncfusion&reg; Essential&reg; JS 2 and more.
 control: How to clear the "Web-service is not listening" to error
 platform: ej2-react
 documentation: ug
@@ -12,7 +12,7 @@ domainurl: ##DomainURL##
 
 ![Alt text](../../pdfviewer/images/webservice.png)
 
-If you are facing a **Web-service is not listening** to error in the Syncfusion® PDF Viewer, there could be several reasons for this. To troubleshoot the issue, you can use the Network tab in your browser's developer tools to gather more information. Here are the steps you can follow:
+If you are facing a **Web-service is not listening** to error in the Syncfusion&reg; PDF Viewer, there could be several reasons for this. To troubleshoot the issue, you can use the Network tab in your browser's developer tools to gather more information. Here are the steps you can follow:
 
 **Step 1:** Open the browser's developer tools by right-clicking on the page and selecting `Inspect` from the dropdown menu. Then Navigate to the `Network` tab. This will show you all of the requests that are being made by the page.
 
@@ -34,7 +34,7 @@ N> Make sure you are connected to the internet and that your connection is stabl
 
 ## File not found
 
-If you are encountering an error message stating that the web service is not listening due to a file not being found in the Syncfusion® PDF viewer, you can try the following steps to resolve the issue:
+If you are encountering an error message stating that the web service is not listening due to a file not being found in the Syncfusion&reg; PDF viewer, you can try the following steps to resolve the issue:
 
 ### Check the file path
 
@@ -42,11 +42,11 @@ Ensure that the file path you use to access the PDF file is correct and that the
 
 ## Document cache not found
 
-The `Document cache not found` exception in Syncfusion® PDF Viewer typically occurs when the cache used to store the rendered pages of a PDF document is not found or has been deleted. This can happen if the cache directory is changed or deleted or if the application is running in a different environment than it was previously.
+The `Document cache not found` exception in Syncfusion&reg; PDF Viewer typically occurs when the cache used to store the rendered pages of a PDF document is not found or has been deleted. This can happen if the cache directory is changed or deleted or if the application is running in a different environment than it was previously.
 
 ### Check for multiple instances
 
-It's possible that you have multiple instances of the Syncfusion® PDF Viewer running simultaneously, which can cause issues with the document cache. To check for this, open the Task Manager on your computer and look for any instances of the Syncfusion® PDF Viewer running. If you find multiple instances, try closing them all and reopening the viewer.
+It's possible that you have multiple instances of the Syncfusion&reg; PDF Viewer running simultaneously, which can cause issues with the document cache. To check for this, open the Task Manager on your computer and look for any instances of the Syncfusion&reg; PDF Viewer running. If you find multiple instances, try closing them all and reopening the viewer.
 
 We can use Redis cache and distributive cache for this issue.
 
@@ -56,11 +56,11 @@ Ensure that your network connection is stable and strong enough to support the w
 
 ## The document pointer does not exist in the cache.
 
-The `Document pointer does not exist in the cache` exception in the Syncfusion® PDF Viewer usually occurs when there is an issue with loading or caching the PDF document. This error can be caused by a variety of reasons, including:
+The `Document pointer does not exist in the cache` exception in the Syncfusion&reg; PDF Viewer usually occurs when there is an issue with loading or caching the PDF document. This error can be caused by a variety of reasons, including:
 
-To clear this error in the Syncfusion® PDF Viewer, you can try the following steps:
+To clear this error in the Syncfusion&reg; PDF Viewer, you can try the following steps:
 
-**Step 1:** Clearing the cache may help resolve the issue. To clear the cache, navigate to the cache location, which can be found in the Syncfusion® PDF Viewer's settings or configuration files. Once you locate the cache folder, delete its contents.
+**Step 1:** Clearing the cache may help resolve the issue. To clear the cache, navigate to the cache location, which can be found in the Syncfusion&reg; PDF Viewer's settings or configuration files. Once you locate the cache folder, delete its contents.
 
 **Step 2:** Try reloading the document to ensure it is loaded correctly. You can do this by calling the controller's Load() method. Ensure the document is not already loaded before attempting to load it again.
 
@@ -68,4 +68,4 @@ To clear this error in the Syncfusion® PDF Viewer, you can try the following st
 
 ## Internal server error
 
-Server-side exceptions happen for various use cases. We can't just define them if they are document-specific, provide the document, or you may need to contact Syncfusion® support for further assistance.
+Server-side exceptions happen for various use cases. We can't just define them if they are document-specific, provide the document, or you may need to contact Syncfusion&reg; support for further assistance.

--- a/blazor/pdfviewer/how-to/webservice-not-listening.md
+++ b/blazor/pdfviewer/how-to/webservice-not-listening.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: How to clear the "Web-service is not listening" to error| Syncfusion&reg;
-description: Learn here all about How to clear the "Web-service is not listening" to error in Syncfusion&reg; React Pdfviewer component of Syncfusion&reg; Essential&reg; JS 2 and more.
+title: How to clear the "Web-service is not listening" to error| Syncfusion
+description: Learn here all about How to clear the "Web-service is not listening" to error in Syncfusion React Pdfviewer component of Syncfusion Essential JS 2 and more.
 control: How to clear the "Web-service is not listening" to error
 platform: ej2-react
 documentation: ug

--- a/blazor/pdfviewer/interaction.md
+++ b/blazor/pdfviewer/interaction.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Interaction mode in Blazor PDF Viewer Component | Syncfusion&reg;
-description: Checkout and learn here all about interaction mode in Syncfusion&reg; Blazor PDF Viewer component and more.
+title: Interaction mode in Blazor PDF Viewer Component | Syncfusion
+description: Checkout and learn here all about interaction mode in Syncfusion Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/interaction.md
+++ b/blazor/pdfviewer/interaction.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Interaction mode in Blazor PDF Viewer Component | Syncfusion®
-description: Checkout and learn here all about interaction mode in Syncfusion® Blazor PDF Viewer component and more.
+title: Interaction mode in Blazor PDF Viewer Component | Syncfusion&reg;
+description: Checkout and learn here all about interaction mode in Syncfusion&reg; Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
 ---
 
-N> Syncfusion® recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
+N> Syncfusion&reg; recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
 
 # Interaction mode in Blazor PDF Viewer Component
 

--- a/blazor/pdfviewer/magnification.md
+++ b/blazor/pdfviewer/magnification.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Magnification in Blazor PDF Viewer Component | Syncfusion&reg;
-description: Checkout and learn here all about magnification in Syncfusion&reg; Blazor PDF Viewer component and much more.
+title: Magnification in Blazor PDF Viewer Component | Syncfusion
+description: Checkout and learn here all about magnification in Syncfusion Blazor PDF Viewer component and much more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/magnification.md
+++ b/blazor/pdfviewer/magnification.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Magnification in Blazor PDF Viewer Component | Syncfusion®
-description: Checkout and learn here all about magnification in Syncfusion® Blazor PDF Viewer component and much more.
+title: Magnification in Blazor PDF Viewer Component | Syncfusion&reg;
+description: Checkout and learn here all about magnification in Syncfusion&reg; Blazor PDF Viewer component and much more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
 ---
 
-N> Syncfusion® recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
+N> Syncfusion&reg; recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
 
 # Magnification in Blazor PDF Viewer Component
 

--- a/blazor/pdfviewer/navigation.md
+++ b/blazor/pdfviewer/navigation.md
@@ -1,17 +1,17 @@
 ---
 layout: post
-title: Navigation in Blazor PDF Viewer Component | Syncfusion®
-description: Checkout and learn here all about navigation in Syncfusion® Blazor PDF Viewer component and much more.
+title: Navigation in Blazor PDF Viewer Component | Syncfusion&reg;
+description: Checkout and learn here all about navigation in Syncfusion&reg; Blazor PDF Viewer component and much more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
 ---
 
-N> Syncfusion® recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
+N> Syncfusion&reg; recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
 
 # Navigation in Blazor PDF Viewer Component
 
-You can navigate between pages in Syncfusion® PDF Viewer in the following ways:
+You can navigate between pages in Syncfusion&reg; PDF Viewer in the following ways:
 
 * Scroll through the pages.
 * Click Go to pages in the built-in toolbar.

--- a/blazor/pdfviewer/navigation.md
+++ b/blazor/pdfviewer/navigation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Navigation in Blazor PDF Viewer Component | Syncfusion&reg;
-description: Checkout and learn here all about navigation in Syncfusion&reg; Blazor PDF Viewer component and much more.
+title: Navigation in Blazor PDF Viewer Component | Syncfusion
+description: Checkout and learn here all about navigation in Syncfusion Blazor PDF Viewer component and much more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/opening-pdf-file.md
+++ b/blazor/pdfviewer/opening-pdf-file.md
@@ -58,7 +58,7 @@ The following code example shows how to open and load the PDF file stored in Azu
         BlobServiceClient blobServiceClient = new BlobServiceClient(connectionString);
         //Container Name
         string containerName = "pdf-file";
-        //File Name to be loaded into Syncfusion&reg; PDF Viewer
+        //File Name to be loaded into Syncfusion PDF Viewer
         string fileName = "Python_Succinctly.pdf";
         BlobContainerClient blobContainerClient = blobServiceClient.GetBlobContainerClient(containerName);
         BlockBlobClient blockBlobClient = blobContainerClient.GetBlockBlobClient(fileName);
@@ -85,7 +85,7 @@ N> The **Azure.Storage.Blobs** NuGet package must be installed in your applicati
         //Connection String of Storage Account
         string connectionString = "Here Place Your Connection string";
         string shareName = "pdfdocument";
-        //File Name to be loaded into Syncfusion&reg; PDF Viewer
+        //File Name to be loaded into Syncfusion PDF Viewer
         string filePath = "Hive_Succinctly.pdf";
         ShareFileClient shareFileClient = new ShareFileClient(connectionString, shareName, filePath);
         Stream stream = shareFileClient.OpenRead();
@@ -135,7 +135,7 @@ N> The **System.Data.SqlClient** package must be installed in your application t
 
 ## Opening a PDF from file system
 
-There is an UI option in built-in toolbar to open the PDF file from local file system. If you want to achieve the same functionality while designing your own toolbar, you can use the following code example to load and open the PDF file. In this sample, the Syncfusion&reg;’s Uploader control is used for Blazor.
+There is an UI option in built-in toolbar to open the PDF file from local file system. If you want to achieve the same functionality while designing your own toolbar, you can use the following code example to load and open the PDF file. In this sample, the Syncfusion&reg; Uploader control is used for Blazor.
 
 ```cshtml
 @using Syncfusion.Blazor.Inputs

--- a/blazor/pdfviewer/opening-pdf-file.md
+++ b/blazor/pdfviewer/opening-pdf-file.md
@@ -1,13 +1,13 @@
 ---
-title: "Opening PDF file in Blazor PDF Viewer Component | Syncfusion®"
+title: "Opening PDF file in Blazor PDF Viewer Component | Syncfusion&reg;"
 component: "PDF Viewer"
-description: "This page helps you to learn about how to load PDF files from various locations in Syncfusion®'s Blazor PDF Viewer."
+description: "This page helps you to learn about how to load PDF files from various locations in Syncfusion&reg; Blazor PDF Viewer."
 platform: Blazor
 control: PDF Viewer
 documentation: ug
 ---
 
-N> Syncfusion® recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
+N> Syncfusion&reg; recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
 
 # Open PDF files in PDF Viewer for Blazor from various storage location
 
@@ -58,7 +58,7 @@ The following code example shows how to open and load the PDF file stored in Azu
         BlobServiceClient blobServiceClient = new BlobServiceClient(connectionString);
         //Container Name
         string containerName = "pdf-file";
-        //File Name to be loaded into Syncfusion® PDF Viewer
+        //File Name to be loaded into Syncfusion&reg; PDF Viewer
         string fileName = "Python_Succinctly.pdf";
         BlobContainerClient blobContainerClient = blobServiceClient.GetBlobContainerClient(containerName);
         BlockBlobClient blockBlobClient = blobContainerClient.GetBlockBlobClient(fileName);
@@ -85,7 +85,7 @@ N> The **Azure.Storage.Blobs** NuGet package must be installed in your applicati
         //Connection String of Storage Account
         string connectionString = "Here Place Your Connection string";
         string shareName = "pdfdocument";
-        //File Name to be loaded into Syncfusion® PDF Viewer
+        //File Name to be loaded into Syncfusion&reg; PDF Viewer
         string filePath = "Hive_Succinctly.pdf";
         ShareFileClient shareFileClient = new ShareFileClient(connectionString, shareName, filePath);
         Stream stream = shareFileClient.OpenRead();
@@ -135,7 +135,7 @@ N> The **System.Data.SqlClient** package must be installed in your application t
 
 ## Opening a PDF from file system
 
-There is an UI option in built-in toolbar to open the PDF file from local file system. If you want to achieve the same functionality while designing your own toolbar, you can use the following code example to load and open the PDF file. In this sample, the Syncfusion®’s Uploader control is used for Blazor.
+There is an UI option in built-in toolbar to open the PDF file from local file system. If you want to achieve the same functionality while designing your own toolbar, you can use the following code example to load and open the PDF file. In this sample, the Syncfusion&reg;’s Uploader control is used for Blazor.
 
 ```cshtml
 @using Syncfusion.Blazor.Inputs

--- a/blazor/pdfviewer/opening-pdf-file.md
+++ b/blazor/pdfviewer/opening-pdf-file.md
@@ -1,7 +1,7 @@
 ---
-title: "Opening PDF file in Blazor PDF Viewer Component | Syncfusion&reg;"
+title: "Opening PDF file in Blazor PDF Viewer Component | Syncfusion"
 component: "PDF Viewer"
-description: "This page helps you to learn about how to load PDF files from various locations in Syncfusion&reg; Blazor PDF Viewer."
+description: "This page helps you to learn about how to load PDF files from various locations in Syncfusion Blazor PDF Viewer."
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/print.md
+++ b/blazor/pdfviewer/print.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Print in Blazor PDF Viewer Component | Syncfusion&reg;
-description: Checkout and learn here all about print in Syncfusion&reg; Blazor PDF Viewer component and much more details.
+title: Print in Blazor PDF Viewer Component | Syncfusion
+description: Checkout and learn here all about print in Syncfusion Blazor PDF Viewer component and much more details.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/print.md
+++ b/blazor/pdfviewer/print.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Print in Blazor PDF Viewer Component | Syncfusion®
-description: Checkout and learn here all about print in Syncfusion® Blazor PDF Viewer component and much more details.
+title: Print in Blazor PDF Viewer Component | Syncfusion&reg;
+description: Checkout and learn here all about print in Syncfusion&reg; Blazor PDF Viewer component and much more details.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
 ---
 
-N> Syncfusion® recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
+N> Syncfusion&reg; recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
 
 # Print in Blazor PDF Viewer Component
 

--- a/blazor/pdfviewer/saving-pdf-file.md
+++ b/blazor/pdfviewer/saving-pdf-file.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Saving PDF file in Blazor PDF Viewer Component | Syncfusion®
-description: Checkout and learn here all about saving PDF file in Syncfusion® Blazor PDF Viewer component and more.
+title: Saving PDF file in Blazor PDF Viewer Component | Syncfusion&reg;
+description: Checkout and learn here all about saving PDF file in Syncfusion&reg; Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
 ---
 
-N> Syncfusion® recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
+N> Syncfusion&reg; recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
 
 # Saving PDF file in Blazor PDF Viewer Component
 

--- a/blazor/pdfviewer/saving-pdf-file.md
+++ b/blazor/pdfviewer/saving-pdf-file.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Saving PDF file in Blazor PDF Viewer Component | Syncfusion&reg;
-description: Checkout and learn here all about saving PDF file in Syncfusion&reg; Blazor PDF Viewer component and more.
+title: Saving PDF file in Blazor PDF Viewer Component | Syncfusion
+description: Checkout and learn here all about saving PDF file in Syncfusion Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/text-search.md
+++ b/blazor/pdfviewer/text-search.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Text Search in Blazor PDF Viewer Component | Syncfusion®
-description: Checkout and learn here all about text search in Syncfusion® Blazor PDF Viewer component and much more.
+title: Text Search in Blazor PDF Viewer Component | Syncfusion&reg;
+description: Checkout and learn here all about text search in Syncfusion&reg; Blazor PDF Viewer component and much more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
 ---
 
-N> Syncfusion® recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
+N> Syncfusion&reg; recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
 
 # Text Search in Blazor PDF Viewer Component
 

--- a/blazor/pdfviewer/text-search.md
+++ b/blazor/pdfviewer/text-search.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Text Search in Blazor PDF Viewer Component | Syncfusion&reg;
-description: Checkout and learn here all about text search in Syncfusion&reg; Blazor PDF Viewer component and much more.
+title: Text Search in Blazor PDF Viewer Component | Syncfusion
+description: Checkout and learn here all about text search in Syncfusion Blazor PDF Viewer component and much more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/toolbar-customization.md
+++ b/blazor/pdfviewer/toolbar-customization.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Toolbar Customization in Blazor PDF Viewer Component | Syncfusion&reg;
-description: Checkout and learn here all about toolbar customization in Syncfusion&reg; Blazor PDF Viewer component and more.
+title: Toolbar Customization in Blazor PDF Viewer Component | Syncfusion
+description: Checkout and learn here all about toolbar customization in Syncfusion Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug

--- a/blazor/pdfviewer/toolbar-customization.md
+++ b/blazor/pdfviewer/toolbar-customization.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Toolbar Customization in Blazor PDF Viewer Component | Syncfusion®
-description: Checkout and learn here all about toolbar customization in Syncfusion® Blazor PDF Viewer component and more.
+title: Toolbar Customization in Blazor PDF Viewer Component | Syncfusion&reg;
+description: Checkout and learn here all about toolbar customization in Syncfusion&reg; Blazor PDF Viewer component and more.
 platform: Blazor
 control: PDF Viewer
 documentation: ug
 ---
 
-N> Syncfusion® recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
+N> Syncfusion&reg; recommends using [Blazor PDF Viewer](https://blazor.syncfusion.com/documentation/pdfviewer-2/getting-started/server-side-application) Component which provides fast rendering of pages and improved performance. Also, there is no need of external Web service for processing the files and ease out the deployment complexity. It can be used in Blazor Server, WASM and MAUI applications without any changes.
 
 # Toolbar Customization in Blazor PDF Viewer Component
 


### PR DESCRIPTION
### Bug description
* Inclusion of the trademark symbol for the "Essential Studio" term.

### Root cause
* The trademark symbol for "Essential Studio" is missing in the NuGet README files.

### Solution description
* Please add the trademark symbol for "Essential Studio" in the relevant Markdown (MD) files for both the development and release branches in the NuGet README files.

### Reason for not identifying earlier
 * [X] The issue did not manifest during initial testing, which is why it was not identified earlier.
     
### Areas tested against this fix
* [x]  Yes

### Is it a breaking issue?
* [x]  No,  this is not a breaking change.
  
### Action taken
*I have added the trademark symbol to all README files for the "Essential Studio" term.

### Feature matrix document updated
* [ ]  Yes
* [ ]  NO
* [x]  NA
 
### Automation details
[x] Yes.


### If the same issue is reproduced in ej2, what will you do?
* [x]  NA
 
 ### Is this common issue needs to be addressed in the same component or on other components in our platform? 
* [ ]  Yes
* [x]  No
  
### Blazor Checklist
Confirm whether this bug is ensured in both Blazor Server and WASM
* [ ]  NA
* [x]  Yes
* [ ]  NO

Is there any new API or existing API name change?
* [ ]  Yes
* [x]  NO
  
Is there any existing behavior change due to this code change?
* [ ]  Yes
* [x]  NO


Do the code changes cause any memory leak and performance issue? (Test only if you suspect that your code may cause problem)
* [ ]  Yes
* [x]  NO

### Reviewer Checklist
* [x]  All provided information is reviewed and ensured.
