### PR TITLE
Blaz 929651-Clear filtering is not working, so it is necessary to handle the null case to prevent the condition

### DIFF
--- a/blazor/datagrid/filter-menu.md
+++ b/blazor/datagrid/filter-menu.md
@@ -1066,7 +1066,7 @@ In the following sample, the `SfDateRangePicker` component is rendered in the fi
     public async Task FilteringHandler(FilteringEventArgs args)
 
     {
-        if (args.ColumnName == "OrderDate")
+        if (args.ColumnName == "OrderDate" && args.FilterPredicates != null)
         {
             args.Cancel = true; //cancel default filter action
             if (Grid.FilterSettings.Columns == null)
@@ -1156,7 +1156,7 @@ In the following sample, the `SfDateRangePicker` component is rendered in the fi
 {% endhighlight %}
 {% endtabs %}
 
-{% previewsample "https://blazorplayground.syncfusion.com/embed/VtBfNiqZXNASChsV?appbar=false&editor=false&result=true&errorlist=false&theme=bootstrap5" %}
+{% previewsample "https://blazorplayground.syncfusion.com/embed/rjLJCLClyfCMmKmA?appbar=false&editor=false&result=true&errorlist=false&theme=bootstrap5" %}
 
 ## Troubleshoot filter menu operator issue
 


### PR DESCRIPTION
Clear Filter issue resolved

_**Before the issue :**_

`  public async Task FilteringHandler(Syncfusion.Blazor.Grids.FilteringEventArgs args)

  {
      if (args.ColumnName == "OrderDate")
  {
  ----------
  }`

_**After the issue was resolved added the below code**_ 

`  public async Task FilteringHandler(Syncfusion.Blazor.Grids.FilteringEventArgs args)

  {
      if (args.ColumnName == "OrderDate" && args.FilterPredicates !=null)
  {
  ----------------------------
  }`

      