### PR TITLE
933125: How to Print large page document in SfPdfViewer added

### DIFF
--- a/blazor/pdfviewer-2/how-to/print-large-page-document.md
+++ b/blazor/pdfviewer-2/how-to/print-large-page-document.md
@@ -50,11 +50,11 @@ const tryPrint = () => {
 };
 ```
 
->N : Ensure that users have pop-ups enabled for your site in their browser settings, as this solution opens the PDF in a new window or tab for printing.
+>N> Ensure that users have pop-ups enabled for your site in their browser settings, as this solution opens the PDF in a new window or tab for printing.
 ![Allow pop-up for large page print window](../../pdfviewer-2/images/allow-popup-largepage-print.png)
 
 [View sample in GitHub](https://github.com/SyncfusionExamples/blazor-pdf-viewer-examples/tree/master/Print/Print%20Large%20page%20document).
 
 ## See also
 
-* [Primary Toolbar Customization in SfPdfViewer](../toolbar-customization.md)
+* [Primary Toolbar Customization in SfPdfViewer](../toolbar-customization)


### PR DESCRIPTION
When attempting to print a PDF document using the Blazor PDF Viewer, each page of the PDF is retrieved as a byte array and converted into an image in Base64 format. This process is memory-intensive, especially for documents with a large number of pages. As the browser handles this resource-heavy operation, it can lead to freezing or unresponsiveness, particularly in environments with limited system resources.

To resolve this issue, we customized the primary toolbar of the SfPdfViewer in the sample. The solution enhances the printing functionality and ensures a smoother performance