### PR TITLE
105925: Removed the SortBy property from ListViewFieldSettings.

### DIFF
--- a/blazor/listview/data-binding.md
+++ b/blazor/listview/data-binding.md
@@ -22,7 +22,6 @@ ListView provides an option to load the data either from local dataSource or rem
 | Child | string | Specifies child dataSource fields. |
 | Tooltip | string | Specifies tooltip title text field. |
 | GroupBy | string | Specifies category of each list item. |
-| SortBy | string | Specifies sorting field, that is used to sort the listview data. |
 | HtmlAttributes | string | Specifies list item html attributes field. |
 
 N> When complex data bind to ListView, you should map the ListViewFieldSettings properly. Otherwise, the ListView properties remains as undefined or null.


### PR DESCRIPTION
### Bug Issue
Removed the SortBy property from ListViewFieldSettings.

### Reason
In the below link, ListViewFieldSettings includes SortBy property. But it is not available in ListView.
https://blazor.syncfusion.com/documentation/listview/data-binding/#data-binding
API link for ListViewFieldSettings : https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.Lists.ListViewFieldSettings-1.html#properties

So, need to remove the field from the ListView documentation.
