### PR TITLE
936482: Added video reference link for Blazor components

### DIFF
--- a/blazor/3D-chart/getting-started-with-web-app.md
+++ b/blazor/3D-chart/getting-started-with-web-app.md
@@ -11,6 +11,11 @@ documentation: ug
 
 This section briefly explains about how to include `Blazor 3D Chart` component in your Blazor Web App using [Visual Studio](https://visualstudio.microsoft.com/vs/) and Visual Studio Code.
 
+To get started quickly with Blazor 3D Chart component, check on the following video:
+
+{% youtube
+"youtube:https://www.youtube.com/watch?v=iCWdoRnu-6s" %}
+
 {% tabcontents %}
 
 {% tabcontent Visual Studio %}

--- a/blazor/accumulation-chart/getting-started.md
+++ b/blazor/accumulation-chart/getting-started.md
@@ -13,6 +13,11 @@ documentation: ug
 
 This section briefly explains about how to include [Blazor Accumulation Chart](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.Charts.SfAccumulationChart.html) component in your Blazor WebAssembly App using Visual Studio and Visual Studio Code.
 
+To get started quickly with Blazor Accumulation Chart component, check on the following video:
+
+{% youtube
+"youtube:https://www.youtube.com/watch?v=ol8c_iH7ebk" %}
+
 {% tabcontents %}
 
 {% tabcontent Visual Studio %}

--- a/blazor/breadcrumb/getting-started.md
+++ b/blazor/breadcrumb/getting-started.md
@@ -11,6 +11,11 @@ documentation: ug
 
 This section briefly explains about how to include [Blazor Breadcrumb](https://www.syncfusion.com/blazor-components/blazor-breadcrumb) component in your Blazor WebAssembly App using Visual Studio and Visual Studio Code.
 
+To get started quickly with Blazor Breadcrumb component, check on the following video:
+
+{% youtube
+"youtube:https://www.youtube.com/watch?v=yWqATPayFS0" %}
+
 {% tabcontents %}
 
 {% tabcontent Visual Studio %}

--- a/blazor/chat-ui/getting-started-webapp.md
+++ b/blazor/chat-ui/getting-started-webapp.md
@@ -11,6 +11,11 @@ documentation: ug
 
 This section briefly explains about how to include [Blazor Chat UI](https://www.syncfusion.com/blazor-components/blazor-chat-ui) component in your Blazor Web App using [Visual Studio](https://visualstudio.microsoft.com/vs/) and Visual Studio Code.
 
+To get started quickly with Blazor Chat UI component, check on the following video:
+
+{% youtube
+"youtube:https://www.youtube.com/watch?v=jNeuk12Kurw" %}
+
 {% tabcontents %}
 
 {% tabcontent Visual Studio %}

--- a/blazor/chip/getting-started.md
+++ b/blazor/chip/getting-started.md
@@ -11,6 +11,11 @@ documentation: ug
 
 This section briefly explains about how to include [Blazor Chip](https://www.syncfusion.com/blazor-components/blazor-chips) component in your Blazor WebAssembly App using Visual Studio and Visual Studio Code.
 
+To get started quickly with Blazor Chip component, check on the following video:
+
+{% youtube
+"youtube:https://www.youtube.com/watch?v=YJtHD8jPwW0" %}
+
 {% tabcontents %}
 
 {% tabcontent Visual Studio %}

--- a/blazor/circular-gauge/getting-started.md
+++ b/blazor/circular-gauge/getting-started.md
@@ -11,10 +11,10 @@ documentation: ug
 
 This section briefly explains about how to include [Blazor CircularGauge](https://www.syncfusion.com/blazor-components/blazor-circular-gauge) component in your Blazor WebAssembly App using Visual Studio and Visual Studio Code.
 
-The below video demonstrates the customization of Blazor Circular Gauge component.
+To get started quickly with Blazor CircularGauge component, check on the following video:
 
 {% youtube
-"youtube:https://www.youtube.com/watch?v=L3TyARQFY98"%}
+"youtube:https://www.youtube.com/watch?v=sAhXjDOTEjc"%}
 
 {% tabcontents %}
 

--- a/blazor/file-upload/getting-started.md
+++ b/blazor/file-upload/getting-started.md
@@ -11,6 +11,11 @@ documentation: ug
 
 This section briefly explains about how to include [Blazor File Upload](https://www.syncfusion.com/blazor-components/blazor-file-upload) component in your Blazor WebAssembly App using Visual Studio and Visual Studio Code.
 
+To get started quickly with Blazor File Upload component, check on the following video:
+
+{% youtube
+"youtube:https://www.youtube.com/watch?v=MxyrifDwud4" %}
+
 {% tabcontents %}
 
 {% tabcontent Visual Studio %}

--- a/blazor/gantt-chart/getting-started.md
+++ b/blazor/gantt-chart/getting-started.md
@@ -11,6 +11,11 @@ documentation: ug
 
 This section briefly explains about how to include [Blazor Gantt Chart](https://www.syncfusion.com/blazor-components/blazor-gantt-chart) component in your Blazor WebAssembly App using Visual Studio and Visual Studio Code.
 
+To get started quickly with Blazor Gantt Chart component, check on the following video:
+
+{% youtube
+"youtube:https://www.youtube.com/watch?v=anPdfXkz0IY" %}
+
 {% tabcontents %}
 
 {% tabcontent Visual Studio %}

--- a/blazor/linear-gauge/getting-started.md
+++ b/blazor/linear-gauge/getting-started.md
@@ -13,6 +13,11 @@ The Blazor LinearGauge is an ideal component for visualizing numeric values in a
 
 This section briefly explains about how to include [Blazor LinearGauge](https://www.syncfusion.com/blazor-components/blazor-linear-gauge) component in your Blazor WebAssembly App using Visual Studio and Visual Studio Code.
 
+To get started quickly with Blazor LinearGauge component, check on the following video:
+
+{% youtube
+"youtube:https://www.youtube.com/watch?v=u6MZxPv1df4" %}
+
 {% tabcontents %}
 
 {% tabcontent Visual Studio %}

--- a/blazor/maps/getting-started.md
+++ b/blazor/maps/getting-started.md
@@ -11,6 +11,11 @@ documentation: ug
 
 This section briefly explains about how to include [Blazor Maps](https://www.syncfusion.com/blazor-components/blazor-map) component in your Blazor WebAssembly App using Visual Studio and Visual Studio Code.
 
+To get started quickly with Blazor Maps component, check on the following video:
+
+{% youtube
+"youtube:https://www.youtube.com/watch?v=AkWI90I7ncE" %}
+
 {% tabcontents %}
 
 {% tabcontent Visual Studio %}

--- a/blazor/otp-input/getting-started-webapp.md
+++ b/blazor/otp-input/getting-started-webapp.md
@@ -11,6 +11,11 @@ documentation: ug
 
 This section briefly explains about how to include `Blazor OTP Input` component in your Blazor Web App using [Visual Studio](https://visualstudio.microsoft.com/vs/) and Visual Studio Code.
 
+To get started quickly with Blazor OTP Input component, check on the following video:
+
+{% youtube
+"youtube:https://www.youtube.com/watch?v=kC4UUo2Gbmc" %}
+
 {% tabcontents %}
 
 {% tabcontent Visual Studio %}

--- a/blazor/pager/getting-started.md
+++ b/blazor/pager/getting-started.md
@@ -11,6 +11,11 @@ documentation: ug
 
 This section briefly explains about how to include Blazor Pager component in your Blazor WebAssembly App using Visual Studio and Visual Studio Code.
 
+To get started quickly with Blazor Pager component, check on the following video:
+
+{% youtube
+"youtube:https://www.youtube.com/watch?v=Nfg8b_bbIfI" %}
+
 {% tabcontents %}
 
 {% tabcontent Visual Studio %}

--- a/blazor/range-selector/getting-started.md
+++ b/blazor/range-selector/getting-started.md
@@ -11,6 +11,11 @@ documentation: ug
 
 This section briefly explains about how to include [Blazor Range Selector](https://www.syncfusion.com/blazor-components/blazor-range-selector) component in your Blazor WebAssembly App using Visual Studio and Visual Studio Code.
 
+To get started quickly with Blazor Range Selector component, check on the following video:
+
+{% youtube
+"youtube:https://www.youtube.com/watch?v=Xtt1h-1QH58" %}
+
 {% tabcontents %}
 
 {% tabcontent Visual Studio %}

--- a/blazor/ribbon/getting-started-webapp.md
+++ b/blazor/ribbon/getting-started-webapp.md
@@ -11,6 +11,11 @@ documentation: ug
 
 This section briefly explains about how to include [Blazor Ribbon](https://www.syncfusion.com/blazor-components/blazor-ribbon) component in your Blazor Web App using [Visual Studio](https://visualstudio.microsoft.com/vs/) and Visual Studio Code.
 
+To get started quickly with Blazor Ribbon component, check on the following video:
+
+{% youtube
+"youtube:https://www.youtube.com/watch?v=bJCpW22KqJM" %}
+
 {% tabcontents %}
 
 {% tabcontent Visual Studio %}

--- a/blazor/signature/getting-started.md
+++ b/blazor/signature/getting-started.md
@@ -11,6 +11,11 @@ documentation: ug
 
 This section briefly explains about how to include [Blazor Signature](https://www.syncfusion.com/blazor-components/blazor-signature) component in your Blazor WebAssembly App using Visual Studio and Visual Studio Code.
 
+To get started quickly with Blazor Signature component, check on the following video:
+
+{% youtube
+"youtube:https://www.youtube.com/watch?v=dBXwBVhmjTg" %}
+
 {% tabcontents %}
 
 {% tabcontent Visual Studio %}

--- a/blazor/smith-chart/getting-started.md
+++ b/blazor/smith-chart/getting-started.md
@@ -11,6 +11,11 @@ documentation: ug
 
 This section briefly explains about how to include [Blazor Smith Chart](https://www.syncfusion.com/blazor-components/blazor-smith-chart) component in your Blazor WebAssembly App using Visual Studio and Visual Studio Code.
 
+To get started quickly with Blazor Smith Chart component, check on the following video:
+
+{% youtube
+"youtube:https://www.youtube.com/watch?v=44vemwNNXio" %}
+
 {% tabcontents %}
 
 {% tabcontent Visual Studio %}

--- a/blazor/sparkline/getting-started.md
+++ b/blazor/sparkline/getting-started.md
@@ -11,6 +11,11 @@ documentation: ug
 
 This section briefly explains about how to include [Blazor Sparkline](https://www.syncfusion.com/blazor-components/blazor-sparkline) component in your Blazor WebAssembly App using Visual Studio and Visual Studio Code.
 
+To get started quickly with Blazor Sparkline component, check on the following video:
+
+{% youtube
+"youtube:https://www.youtube.com/watch?v=f6CS_zwDvqg" %}
+
 {% tabcontents %}
 
 {% tabcontent Visual Studio %}

--- a/blazor/stepper/getting-started.md
+++ b/blazor/stepper/getting-started.md
@@ -11,6 +11,11 @@ documentation: ug
 
 This section briefly explains about how to include [Blazor Stepper](https://www.syncfusion.com/blazor-components/blazor-stepper) component in your Blazor WebAssembly App using Visual Studio and Visual Studio Code.
 
+To get started quickly with Blazor Stepper component, check on the following video:
+
+{% youtube
+"youtube:https://www.youtube.com/watch?v=JRsM_x7vtyE" %}
+
 {% tabcontents %}
 
 {% tabcontent Visual Studio %}

--- a/blazor/textarea/getting-started-webapp.md
+++ b/blazor/textarea/getting-started-webapp.md
@@ -11,6 +11,11 @@ documentation: ug
 
 This section briefly explains about how to include [Blazor TextArea](https://www.syncfusion.com/blazor-components/blazor-TextArea) component in your Blazor Web App using [Visual Studio](https://visualstudio.microsoft.com/vs/) and Visual Studio Code.
 
+To get started quickly with Blazor TextArea component, check on the following video:
+
+{% youtube
+"youtube:https://www.youtube.com/watch?v=4qrr0FXvzMA" %}
+
 {% tabcontents %}
 
 {% tabcontent Visual Studio %}

--- a/blazor/treemap/getting-started.md
+++ b/blazor/treemap/getting-started.md
@@ -11,10 +11,10 @@ documentation: ug
 
 This section briefly explains about how to include [Blazor TreeMap](https://www.syncfusion.com/blazor-components/blazor-treemap) component in your Blazor WebAssembly App using Visual Studio and Visual Studio Code.
 
-The below video demonstrates the customization of Blazor TreeMap component.
+To get started quickly with Blazor TreeMap component, check on the following video:
 
 {% youtube
-"youtube:https://www.youtube.com/watch?v=FOpV4mu9GH4"%}
+"youtube:https://www.youtube.com/watch?v=j01ZNzIe4eo"%}
 
 {% tabcontents %}
 


### PR DESCRIPTION
I added video reference link for missing Blazor components getting started UG documentation.

Stepper
Sparkline
SmithChart
Signature
TreeMap
TextArea
Range Selector
Pager
OTP Input
Linear Gauge
Circular Gauge
Chips
Chat UI
Breadcrumb
3D Chart
Ribbon
Gantt Chart
Maps
Accumulation Chart
File Upload