### PR TITLE
947270: Removed the Usage Sub tittle in FormDesigner Programmatic Documentation

### DIFF
--- a/blazor/pdfviewer-2/form-designer/create-programmatically.md
+++ b/blazor/pdfviewer-2/form-designer/create-programmatically.md
@@ -118,8 +118,6 @@ The following image illustrates the listbox field thickness customization in Bla
 
 The [`SetFormDrawingModeAsync`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerBase.html#Syncfusion_Blazor_SfPdfViewer_PdfViewerBase_SetFormDrawingModeAsync_System_Nullable_Syncfusion_Blazor_SfPdfViewer_FormFieldType__) method allows defining the type of form field that can be drawn in the PDF Viewer. This enables users to add form fields interactively.
 
-### Usage
-
 - **Setting Form Field Mode:** Specify a [`FormFieldType`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.FormFieldType.html) to allow adding a specific form field.
 - **Clearing Form Field Mode:** Reset the form field selection by calling [`SetFormDrawingModeAsync()`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.SfPdfViewer.PdfViewerBase.html#Syncfusion_Blazor_SfPdfViewer_PdfViewerBase_SetFormDrawingModeAsync_System_Nullable_Syncfusion_Blazor_SfPdfViewer_FormFieldType__) without parameters.
 


### PR DESCRIPTION
Removed the Usage Sub tittle in FormDesigner Programmatic Documentation