### PR TITLE
947405: Child nodes are not rendered in the Dropdown Tree with the We…

### DIFF
--- a/blazor/dropdown-tree/data-binding.md
+++ b/blazor/dropdown-tree/data-binding.md
@@ -366,7 +366,7 @@ The **OrderID**, **EmployeeID**, and **ShipName** columns from orders table have
 
 ### Web API Adaptor
 
-In the following example, `WebApiAdaptor` is  used to fetch data from server side. Within the initial request entire data will be returned.
+In the following example, `WebApiAdaptor` is  used to fetch data from server side. In the initial request, entire data will be returned.
 
 ```cshtml
 @using Syncfusion.Blazor.Navigations
@@ -789,7 +789,7 @@ namespace DBTree.Data
 
 #### Creating web API controller
 
- A Web API Controller has to be created, which allows the Dropdown Tree to directly consume data from the Entity Framework. Within the initial request entire data will be returned.
+ A Web API Controller has to be created, which allows the Dropdown Tree to directly consume data from the Entity Framework. In the initial request, entire data will be returned.
 
 ```csharp
 using DBTree.Data;

--- a/blazor/dropdown-tree/data-binding.md
+++ b/blazor/dropdown-tree/data-binding.md
@@ -366,7 +366,7 @@ The **OrderID**, **EmployeeID**, and **ShipName** columns from orders table have
 
 ### Web API Adaptor
 
-In the following example, `WebApiAdaptor` is  used to fetch data from server side.
+In the following example, `WebApiAdaptor` is  used to fetch data from server side. Within the initial request entire data will be returned.
 
 ```cshtml
 @using Syncfusion.Blazor.Navigations
@@ -415,23 +415,8 @@ namespace DropDownTreeSample.Controllers
                 new NodeResult { ProductID = 5, ProductName = "SubChild1", pid = 3, haschild = false },
                 new NodeResult { ProductID = 6, ProductName = "SubChild2", pid = 3, haschild = false },
             };
-
             var data = localData.ToList();
-            var queryString = Request.Query;
-
-            if (queryString.Keys.Contains("$filter"))
-            {
-                string filter = string.Join("", queryString["$filter"].ToString().Split(' ').Skip(2)); // get filter from querystring
-                // filter the data based on the expand node id.
-                data = data.Where(d => d.pid.ToString() == filter).ToList();
-                return data;
-            }
-            else
-            {
-                // if the parent id is null.
-                data = data.Where(d => d.pid == null).ToList();
-                return data;
-            }
+            return data;
         }
 
         public class NodeResult
@@ -804,7 +789,7 @@ namespace DBTree.Data
 
 #### Creating web API controller
 
- A Web API Controller has to be created, which allows the Dropdown Tree to directly consume data from the Entity Framework.
+ A Web API Controller has to be created, which allows the Dropdown Tree to directly consume data from the Entity Framework. Within the initial request entire data will be returned.
 
 ```csharp
 using DBTree.Data;
@@ -823,22 +808,7 @@ namespace DBTree.Controller
         {
             // Get the DataSource from Database
             var data = db.GetAllEmployees().ToList();
-            var queryString = Request.Query;
-            if (queryString.Keys.Contains("$filter"))
-            {
-                StringValues Skip;
-                StringValues Take;
-                int skip = (queryString.TryGetValue("$skip", out Skip)) ? Convert.ToInt32(Skip[0]) : 0;
-                int top = (queryString.TryGetValue("$top", out Take)) ? Convert.ToInt32(Take[0]) : data.Count();
-                string filter = string.Join("", queryString["$filter"].ToString().Split(' ').Skip(2)); // get filter from querystring
-                data = data.Where(d => d.PId?.ToString() == filter).ToList();
-                return data.Skip(skip).Take(top);
-            }
-            else
-            {
-                data = data.Where(d => d.PId == null).ToList();
-                return data;
-            }
+            return data;
         }
     }
 }


### PR DESCRIPTION
### Description

Modify the Webapi adaptor samples content and controller code.

### Solution Description

We have changed the datasource handling behavior in the Dropdown Tree component. So we have to return the entire datasource  within a initial request thereby rendering the entire data source in the Dropdown Tree component.

Behavior changes PR link: https://github.com/essential-studio/ej2-blazor-source/pull/13946/files#diff-811cd6673443cad30ecaf4e0062d832d70a052b7eaa0a968eb54e45c43f12b4aR165
Task link: https://dev.azure.com/EssentialStudio/Ej2-Web/_workitems/edit/866309