### PR TITLE
SEO-174654-Duplicate-Title-Issue-Fix

### DIFF
--- a/blazor/diagram/interaction.md
+++ b/blazor/diagram/interaction.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Interaction in Blazor Diagram Component | Syncfusion
+title: Connector Interactions in Blazor Diagram Component | Syncfusion
 description: Checkout and learn here all about interaction in Syncfusion Blazor Diagram component and much more details.
 platform: Blazor
 control: Diagram Component
 documentation: ug
 ---
 
-# Interaction in Blazor Diagram Component
+# Connector Interactions in Blazor Diagram Component
 
 ## Selection
 

--- a/blazor/diagram/interaction.md
+++ b/blazor/diagram/interaction.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Connector Interactions in Blazor Diagram Component | Syncfusion
-description: Checkout and learn here all about interaction in Syncfusion Blazor Diagram component and much more details.
+description: Checkout and learn here all about connector interaction in Syncfusion Blazor Diagram component and much more details.
 platform: Blazor
 control: Diagram Component
 documentation: ug


### PR DESCRIPTION
Hi @MallikaRK 

|Title|Description|
|--|--|
|Task Category| Blazor Duplicate title and H1|
|Content Task Link/Mail Screenshot| ![image](https://github.com/user-attachments/assets/ebc9fe72-523e-417a-8709-105d3595fb68) ![image](https://github.com/user-attachments/assets/c5b85a01-6fe7-45ce-841e-b7c0e19f2fdb)|
|UX task| NA|
|Dev PR link| N/A|
|Ticket/Task link| |

Changes Made | Reason for change |
-- | -- |
Fixed the duplicate title and H1| To avoid duplicate meta elements in different documentation pages|

Regards,
Dickson