### PR TITLE
SEO-202684-blazor-datagrid-local-data-docs-bing-report

### DIFF
--- a/blazor/datagrid/local-data.md
+++ b/blazor/datagrid/local-data.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Local Data in Blazor DataGrid | Syncfusion
-description: Checkout and learn here all about Local Data in Syncfusion Blazor DataGrid and much more.
+description: Checkout and learn here all about Local Data in Syncfusion Blazor DataGrid Component and much more details.
 platform: Blazor
 control: DataGrid
 documentation: ug


### PR DESCRIPTION
@MallikaRK 

|Title|Description|
|--|--|
|Task Category|Bing report-Meta description too short|
|Content Task Link/Mail Screenshot| NA|
|UX task| NA|
|Hotfix PR|https://github.com/syncfusion-content/blazor-docs/pull/6121|
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/202684|
|Excel/SharePoint link|https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7B80B7E540-D71F-4A38-8DF0-BC6FDF9BA10C%7D&file=Meta%20descriptions%20on%20many%20of%20your%20pages%20are%20too%20short..xlsx&action=default&mobileredirect=true&ovuser=77f1fe12-b049-4919-8c50-9fb41e5bb63b%2Casha.bhaskaran%40syncfusion.com&clickparams=eyJBcHBOYW1lIjoiVGVhbXMtRGVza3RvcCIsIkFwcFZlcnNpb24iOiI0OS8yNTA1MDQwMTYyMiIsIkhhc0ZlZGVyYXRlZFVzZXIiOmZhbHNlfQ%3D%3D |

|Changes made|Reason for changes|
|--|--|
|Adding character in the description count |  To get the right description character count from 100-160 |     



Regards,
Hillary