### PR TITLE
SEO-204026-Meta-Description-too-short-hotfix

### DIFF
--- a/blazor/combobox/value-binding.md
+++ b/blazor/combobox/value-binding.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  Data Binding in Blazor ComboBox Component | Syncfusion
-description: Checkout and learn here all about value binding in Syncfusion Blazor ComboBox component and more.
+description: Checkout and learn here everything about value binding in Syncfusion Blazor ComboBox component and more.
 platform: Blazor
 control: ComboBox
 documentation: ug

--- a/blazor/datagrid/accessibility.md
+++ b/blazor/datagrid/accessibility.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Accessibility in Blazor DataGrid | Syncfusion
-description: Checkout and learn here all about accessibility in Syncfusion Blazor DataGrid and much more.
+description: Checkout and easily learn everything about accessibility in Syncfusion Blazor DataGrid and much more.
 platform: Blazor
 control: DataGrid
 documentation: ug

--- a/blazor/datagrid/caption-template.md
+++ b/blazor/datagrid/caption-template.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Caption template in Blazor DataGrid | Syncfusion
-description: Checkout and learn here all about Grouping in Syncfusion Blazor DataGrid and much more details.
+description: Checkout and learn here everything about Grouping in Syncfusion Blazor DataGrid and much more details. 
 platform: Blazor
 control: DataGrid
 documentation: ug

--- a/blazor/datagrid/cell.md
+++ b/blazor/datagrid/cell.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Cell in Blazor DataGrid | Syncfusion
-description: Checkout and learn here all about the Cell in the Syncfusion Blazor DataGrid and much more.
+description: Checkout and learn here everything about the Cell in the Syncfusion Blazor DataGrid and much more quickly.
 platform: Blazor
 control: DataGrid
 documentation: ug

--- a/blazor/datagrid/context-menu.md
+++ b/blazor/datagrid/context-menu.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Context Menu in Blazor DataGrid | Syncfusion
-description: Checkout and learn here all about Context Menu in Syncfusion Blazor DataGrid and much more.
+description: Checkout and learn here everything about Context Menu in Syncfusion Blazor DataGrid and much more easily. 
 platform: Blazor
 control: DataGrid
 documentation: ug

--- a/blazor/datagrid/data-annotation.md
+++ b/blazor/datagrid/data-annotation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Data Annotation in Blazor DataGrid | Syncfusion
-description: Learn all about Data Annotation in Syncfusion Blazor DataGrid and more.
+description: Check out and learn here everything about Data Annotation in Syncfusion Blazor DataGrid and much more. 
 platform: Blazor
 control: DataGrid
 documentation: ug

--- a/blazor/datagrid/editing.md
+++ b/blazor/datagrid/editing.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Editing in Blazor DataGrid | Syncfusion
-description: Checkout and learn here all about Editing in Syncfusion Blazor DataGrid and much more details.
+description: Checkout and learn here everything about Editing in Syncfusion Blazor DataGrid and much more details.
 platform: Blazor
 control: DataGrid
 documentation: ug

--- a/blazor/datagrid/excel-exporting.md
+++ b/blazor/datagrid/excel-exporting.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Excel Export in Blazor DataGrid | Syncfusion
-description: Checkout and learn here all about Excel Export in Syncfusion Blazor DataGrid and much more.
+description: Check out and learn here everything about Excel Export in Syncfusion Blazor DataGrid and much more details.
 platform: Blazor
 control: DataGrid
 documentation: ug

--- a/blazor/datagrid/filter-bar.md
+++ b/blazor/datagrid/filter-bar.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Filter Bar in Blazor DataGrid | Syncfusion
-description: Checkout and learn here all about Filter Bar in Syncfusion Blazor DataGrid and much more details.
+description: Check out and learn here everything about Filter Bar in Syncfusion Blazor DataGrid and much more details. 
 platform: Blazor
 control: DataGrid
 documentation: ug

--- a/blazor/datagrid/filtering.md
+++ b/blazor/datagrid/filtering.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Filtering in Blazor DataGrid | Syncfusion
-description: Checkout and learn here all about Filtering in Syncfusion Blazor DataGrid and much more details.
+description: Check out and learn here everthing about Filtering in Syncfusion Blazor DataGrid and many more details.
 platform: Blazor
 control: DataGrid
 documentation: ug

--- a/blazor/datagrid/grouping.md
+++ b/blazor/datagrid/grouping.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Grouping in Blazor DataGrid | Syncfusion
-description: Checkout and learn here all about Grouping in Syncfusion Blazor DataGrid and much more details.
+description: Check out and learn here everything about Grouping in Syncfusion Blazor DataGrid and much more details. 
 platform: Blazor
 control: DataGrid
 documentation: ug

--- a/blazor/datagrid/how-to/customize-empty-grid-display-message.md
+++ b/blazor/datagrid/how-to/customize-empty-grid-display-message.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Customize the Empty Record Template in the Blazor DataGrid | Syncfusion
-description: Learn here all about customize the empty record template in Syncfusion Blazor DataGrid.
+description: Check out and learn here everything about customize the empty record template in Syncfusion Blazor DataGrid. 
 platform: Blazor
 control: DataGrid
 documentation: ug

--- a/blazor/datagrid/how-to/resize-grid-in-various-dimension.md
+++ b/blazor/datagrid/how-to/resize-grid-in-various-dimension.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Resize the Blazor DataGrid in various dimension | Syncfusion
-description: Learn here all about resize the Grid in various dimension in Syncfusion Blazor DataGrid.
+description: Check out and learn here all about resize the Grid in various dimension in Syncfusion Blazor DataGrid and much more.
 platform: Blazor
 control: DataGrid
 documentation: ug

--- a/blazor/datagrid/pdf-export-options.md
+++ b/blazor/datagrid/pdf-export-options.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: PDF Export Options in Blazor DataGrid | Syncfusion
-description: Checkout and learn here all about PDF Export Options in Syncfusion Blazor DataGrid and much more.
+description: Check out and easily learn here everything about Row in Syncfusion Blazor DataGrid and much more details.
 platform: Blazor
 control: DataGrid
 documentation: ug

--- a/blazor/datagrid/row-template.md
+++ b/blazor/datagrid/row-template.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Row Template in Blazor DataGrid | Syncfusion
-description: Checkout and learn here all about Row Template in Syncfusion Blazor DataGrid and much more details.
+description: Checkout and learn here everything about Row Template in Syncfusion Blazor DataGrid and much more details.
 platform: Blazor
 control: DataGrid
 documentation: ug

--- a/blazor/datagrid/style-and-appearance/filtering.md
+++ b/blazor/datagrid/style-and-appearance/filtering.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Filtering customization in Blazor DataGrid | Syncfusion
-description: Learn here all about filtering in Syncfusion Blazor DataGrid and more.
+description: Check out and learn here everything about filtering in Syncfusion Blazor DataGrid and much more details. 
 platform: Blazor
 control: DataGrid
 documentation: ug

--- a/blazor/datagrid/style-and-appearance/grouping.md
+++ b/blazor/datagrid/style-and-appearance/grouping.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Grouping customization in Blazor DataGrid | Syncfusion
-description: Learn here all about grouping in Syncfusion Blazor DataGrid and more.
+description: Check out and learn here everything about grouping in Syncfusion Blazor DataGrid and much more details. 
 platform: Blazor
 control: DataGrid
 documentation: ug

--- a/blazor/datagrid/style-and-appearance/style-and-appearance.md
+++ b/blazor/datagrid/style-and-appearance/style-and-appearance.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Style and appearance in Blazor DataGrid | Syncfusion
-description: Checkout and learn here all about style and appearance in Syncfusion Blazor DataGrid and more.
+description: Checkout and learn here all about style and appearance in Syncfusion Blazor DataGrid and much more details. 
 platform: Blazor
 control: DataGrid
 documentation: ug

--- a/blazor/datagrid/virtual-scrolling.md
+++ b/blazor/datagrid/virtual-scrolling.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Virtualization in Blazor DataGrid | Syncfusion
-description: Checkout and learn here all about Virtualization in Syncfusion Blazor DataGrid and much more.
+description: Check out and learn here all about Virtualization in Syncfusion Blazor DataGrid and much more details.
 platform: Blazor
 control: DataGrid
 documentation: ug


### PR DESCRIPTION
Hi @MallikaRK 

Title | Description
-- | --
|Task Category |Meta description too short|
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/204026/|
|Share point| [share point](https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7B425BC1DA-899F-43C9-83EC-59BDC2E6D2D3%7D&file=Bing%20Issues%20-%20SEO.xlsx&action=default&mobileredirect=true)|



Changes Made | Reason for change |
|-- | -- |
|Change the meta description| I updated the SEO meta description to be over 100 characters in length.| 




Regards, 
Asha