### PR TITLE
965796: Adding documentation content to the dynamic target feature of tooltip component

### DIFF
--- a/blazor/tooltip/target.md
+++ b/blazor/tooltip/target.md
@@ -6,6 +6,7 @@ platform: Blazor
 control: Tooltip
 documentation: ug
 ---
+
 # Target
 
 The [`Target`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.Popups.SfTooltip.html#Syncfusion_Blazor_Popups_SfTooltip_Target) property specifies the target selector where the Tooltip needs to be displayed. It enables Tooltip activation on specific DOM elements based on user interactions like hover or focus.
@@ -15,6 +16,7 @@ The [`Target`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.Popups.Sf
  <SfButton ID="btn" Content="Show Tooltip"></SfButton>
 </SfTooltip>
 ```
+
 ![Blazor Tooltip Target](images/target.png)
 
 ## Displaying Tooltip for dynamically created target element

--- a/blazor/tooltip/target.md
+++ b/blazor/tooltip/target.md
@@ -10,7 +10,7 @@ documentation: ug
 
 The [`Target`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.Popups.SfTooltip.html#Syncfusion_Blazor_Popups_SfTooltip_Target) property specifies the target selector where the Tooltip needs to be displayed. It enables Tooltip activation on specific DOM elements based on user interactions like hover or focus.
 
-```razor
+```cshtml
 <SfTooltip Content="Let's go green to save the planet!!" Target="#btn" >
  <SfButton ID="btn" Content="Show Tooltip"></SfButton>
 </SfTooltip>
@@ -23,7 +23,7 @@ The Tooltip component can be configured to display Tooltips for elements that ar
 
 Set the [`TargetContainer`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.Popups.SfTooltip.html#Syncfusion_Blazor_Popups_SfTooltip_TargetContainer) property using a CSS selector that defines the container in which Tooltip target elements will be automatically display Tooltips. All elements inside this container that match the Target selector will automatically show Tooltips, including those added after the component is rendered—no extra setup needed.
 
-```razor
+```cshtml
 @using Syncfusion.Blazor.Popups
 @using Syncfusion.Blazor.Buttons
 


### PR DESCRIPTION
### Feature description

[UG DOCUMENTATION 965796](https://dev.azure.com/EssentialStudio/Ej2-Web/_workitems/edit/965796) - Create UG Documentation for dynamic target feature of tooltip component

### Root Cause / Analysis

The documentation for the dynamic target feature was not previously available in the Blazor section. It has now been added.

### Reason for not identifying earlier

* If any other reason, provide the details here. 

### Is Breaking issue.?

NO

### Is reported by customer in incident/forum.?

NO

### Solution Description

1.Added the missing documentation for the dynamic-target feature in the Blazor Tooltip component.

### Areas affected and ensured

No areas were impacted by this change.

### E2E report details against this fix

NA

### Did you included unit test cases.?

No

### Is there any API name changes.?

No

### Reviewer Checklist

* [ ] All provided information are reviewed and ensured. 