### PR TITLE
docs (959535): Need to resolve the prompts property gets updated with user input, causing PromptRequested logic to always detect existing prompt in Blazor AI assitview issue

### DIFF
--- a/blazor/ai-assistview/assist-view.md
+++ b/blazor/ai-assistview/assist-view.md
@@ -81,10 +81,9 @@ The `Prompts` collection stores all the prompts and responses generated.
     private async Task PromptRequest(AssistViewPromptRequestedEventArgs args)
     {
         await Task.Delay(1000);
-        var isPromptFound = prompts.Any(prompt => prompt.Prompt == args.Prompt);
         var promptData = prompts.FirstOrDefault(prompt => prompt.Prompt == args.Prompt);
         var defaultResponse = "For real-time prompt processing, connect the AI AssistView component to your preferred AI service, such as OpenAI or Azure Cognitive Services. Ensure you obtain the necessary API credentials to authenticate and enable seamless integration.";
-        args.Response = isPromptFound ? promptData.Response : defaultResponse;
+        args.Response = string.IsNullOrEmpty(promptData.Response) ? defaultResponse : promptData.Response;
     }
 }
 
@@ -168,10 +167,9 @@ You can customize the appearance of the prompter avatar by using the [PromptIcon
     private async Task PromptRequest(AssistViewPromptRequestedEventArgs args)
     {
         await Task.Delay(1000);
-        var isPromptFound = prompts.Any(prompt => prompt.Prompt == args.Prompt);
         var promptData = prompts.FirstOrDefault(prompt => prompt.Prompt == args.Prompt);
         var defaultResponse = "For real-time prompt processing, connect the AI AssistView component to your preferred AI service, such as OpenAI or Azure Cognitive Services. Ensure you obtain the necessary API credentials to authenticate and enable seamless integration.";
-        args.Response = isPromptFound ? promptData.Response : defaultResponse;
+        args.Response = string.IsNullOrEmpty(promptData.Response) ? defaultResponse : promptData.Response;
     }
 }
 
@@ -199,10 +197,9 @@ You can use the [ResponseIconCss](https://help.syncfusion.com/cr/blazor/Syncfusi
     private async Task PromptRequest(AssistViewPromptRequestedEventArgs args)
     {
         await Task.Delay(1000);
-        var isPromptFound = prompts.Any(prompt => prompt.Prompt == args.Prompt);
         var promptData = prompts.FirstOrDefault(prompt => prompt.Prompt == args.Prompt);
         var defaultResponse = "For real-time prompt processing, connect the AI AssistView component to your preferred AI service, such as OpenAI or Azure Cognitive Services. Ensure you obtain the necessary API credentials to authenticate and enable seamless integration.";
-        args.Response = isPromptFound ? promptData.Response : defaultResponse;
+        args.Response = string.IsNullOrEmpty(promptData.Response) ? defaultResponse : promptData.Response;
     }
 }
 

--- a/blazor/ai-assistview/templates.md
+++ b/blazor/ai-assistview/templates.md
@@ -98,10 +98,9 @@ You can use the [PromptItemTemplate](https://help.syncfusion.com/cr/blazor/Syncf
     private async Task PromptRequest(AssistViewPromptRequestedEventArgs args)
     {
         await Task.Delay(1000);
-        var isPromptFound = prompts.Any(prompt => prompt.Prompt == args.Prompt);
         var promptData = prompts.FirstOrDefault(prompt => prompt.Prompt == args.Prompt);
         var defaultResponse = "For real-time prompt processing, connect the AI AssistView component to your preferred AI service, such as OpenAI or Azure Cognitive Services. Ensure you obtain the necessary API credentials to authenticate and enable seamless integration.";
-        args.Response = isPromptFound ? promptData.Response : defaultResponse;
+        args.Response = string.IsNullOrEmpty(promptData.Response) ? defaultResponse : promptData.Response;
     }
 }
 <style>
@@ -169,10 +168,9 @@ You can use the [ResponseItemTemplate](https://help.syncfusion.com/cr/blazor/Syn
     private async Task PromptRequest(AssistViewPromptRequestedEventArgs args)
     {
         await Task.Delay(1000);
-        var isPromptFound = prompts.Any(prompt => prompt.Prompt == args.Prompt);
         var promptData = prompts.FirstOrDefault(prompt => prompt.Prompt == args.Prompt);
         var defaultResponse = "For real-time prompt processing, connect the AI AssistView component to your preferred AI service, such as OpenAI or Azure Cognitive Services. Ensure you obtain the necessary API credentials to authenticate and enable seamless integration.";
-        args.Response = isPromptFound ? promptData.Response : defaultResponse;
+        args.Response = string.IsNullOrEmpty(promptData.Response) ? defaultResponse : promptData.Response;
     }
 }
 <style>

--- a/blazor/ai-assistview/toolbar-items.md
+++ b/blazor/ai-assistview/toolbar-items.md
@@ -397,10 +397,9 @@ In the following example, AI AssistView component rendered with built-in toolbar
     private async Task PromptRequest(AssistViewPromptRequestedEventArgs args)
     {
         await Task.Delay(1000);
-        var isPromptFound = prompts.Any(prompt => prompt.Prompt == args.Prompt);
         var promptData = prompts.FirstOrDefault(prompt => prompt.Prompt == args.Prompt);
         var defaultResponse = "For real-time prompt processing, connect the AI AssistView component to your preferred AI service, such as OpenAI or Azure Cognitive Services. Ensure you obtain the necessary API credentials to authenticate and enable seamless integration.";
-        args.Response = isPromptFound ? promptData.Response : defaultResponse;
+        args.Response = string.IsNullOrEmpty(promptData.Response) ? defaultResponse : promptData.Response;
     }
 }
 
@@ -430,10 +429,9 @@ You can use the [Width](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.
     private async Task PromptRequest(AssistViewPromptRequestedEventArgs args)
     {
         await Task.Delay(1000);
-        var isPromptFound = prompts.Any(prompt => prompt.Prompt == args.Prompt);
         var promptData = prompts.FirstOrDefault(prompt => prompt.Prompt == args.Prompt);
         var defaultResponse = "For real-time prompt processing, connect the AI AssistView component to your preferred AI service, such as OpenAI or Azure Cognitive Services. Ensure you obtain the necessary API credentials to authenticate and enable seamless integration.";
-        args.Response = isPromptFound ? promptData.Response : defaultResponse;
+        args.Response = string.IsNullOrEmpty(promptData.Response) ? defaultResponse : promptData.Response;
     }
 }
 
@@ -461,10 +459,9 @@ You can define [ItemClicked](https://help.syncfusion.com/cr/blazor/Syncfusion.Bl
     private async Task PromptRequest(AssistViewPromptRequestedEventArgs args)
     {
         await Task.Delay(1000);
-        var isPromptFound = prompts.Any(prompt => prompt.Prompt == args.Prompt);
         var promptData = prompts.FirstOrDefault(prompt => prompt.Prompt == args.Prompt);
         var defaultResponse = "For real-time prompt processing, connect the AI AssistView component to your preferred AI service, such as OpenAI or Azure Cognitive Services. Ensure you obtain the necessary API credentials to authenticate and enable seamless integration.";
-        args.Response = isPromptFound ? promptData.Response : defaultResponse;
+        args.Response = string.IsNullOrEmpty(promptData.Response) ? defaultResponse : promptData.Response;
     }
     private void ToolbarItemClicked(AssistViewToolbarItemClickedEventArgs args)
     {
@@ -496,10 +493,9 @@ In the following example, AI AssistView renders with built-in toolbar items.
     private async Task PromptRequest(AssistViewPromptRequestedEventArgs args)
     {
         await Task.Delay(1000);
-        var isPromptFound = prompts.Any(prompt => prompt.Prompt == args.Prompt);
         var promptData = prompts.FirstOrDefault(prompt => prompt.Prompt == args.Prompt);
         var defaultResponse = "For real-time prompt processing, connect the AI AssistView component to your preferred AI service, such as OpenAI or Azure Cognitive Services. Ensure you obtain the necessary API credentials to authenticate and enable seamless integration.";
-        args.Response = isPromptFound ? promptData.Response : defaultResponse;
+        args.Response = string.IsNullOrEmpty(promptData.Response) ? defaultResponse : promptData.Response;
     }
 }
 
@@ -529,10 +525,9 @@ You can use the [Width](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.
     private async Task PromptRequest(AssistViewPromptRequestedEventArgs args)
     {
         await Task.Delay(1000);
-        var isPromptFound = prompts.Any(prompt => prompt.Prompt == args.Prompt);
         var promptData = prompts.FirstOrDefault(prompt => prompt.Prompt == args.Prompt);
         var defaultResponse = "For real-time prompt processing, connect the AI AssistView component to your preferred AI service, such as OpenAI or Azure Cognitive Services. Ensure you obtain the necessary API credentials to authenticate and enable seamless integration.";
-        args.Response = isPromptFound ? promptData.Response : defaultResponse;
+        args.Response = string.IsNullOrEmpty(promptData.Response) ? defaultResponse : promptData.Response;
     }
 }
 
@@ -560,10 +555,9 @@ You can define [ItemClicked](https://help.syncfusion.com/cr/blazor/Syncfusion.Bl
     private async Task PromptRequest(AssistViewPromptRequestedEventArgs args)
     {
         await Task.Delay(1000);
-        var isPromptFound = prompts.Any(prompt => prompt.Prompt == args.Prompt);
         var promptData = prompts.FirstOrDefault(prompt => prompt.Prompt == args.Prompt);
         var defaultResponse = "For real-time prompt processing, connect the AI AssistView component to your preferred AI service, such as OpenAI or Azure Cognitive Services. Ensure you obtain the necessary API credentials to authenticate and enable seamless integration.";
-        args.Response = isPromptFound ? promptData.Response : defaultResponse;
+        args.Response = string.IsNullOrEmpty(promptData.Response) ? defaultResponse : promptData.Response;
     }
     private void ToolbarItemClicked(AssistViewToolbarItemClickedEventArgs args)
     {
@@ -603,10 +597,9 @@ You can use the [PromptToolbarItem](https://help.syncfusion.com/cr/blazor/Syncfu
     private async Task PromptRequest(AssistViewPromptRequestedEventArgs args)
     {
         await Task.Delay(1000);
-        var isPromptFound = prompts.Any(prompt => prompt.Prompt == args.Prompt);
         var promptData = prompts.FirstOrDefault(prompt => prompt.Prompt == args.Prompt);
         var defaultResponse = "For real-time prompt processing, connect the AI AssistView component to your preferred AI service, such as OpenAI or Azure Cognitive Services. Ensure you obtain the necessary API credentials to authenticate and enable seamless integration.";
-        args.Response = isPromptFound ? promptData.Response : defaultResponse;
+        args.Response = string.IsNullOrEmpty(promptData.Response) ? defaultResponse : promptData.Response;
     }
 }
 
@@ -643,10 +636,9 @@ You can use the [ResponseToolbarItem](https://help.syncfusion.com/cr/blazor/Sync
     private async Task PromptRequest(AssistViewPromptRequestedEventArgs args)
     {
         await Task.Delay(1000);
-        var isPromptFound = prompts.Any(prompt => prompt.Prompt == args.Prompt);
         var promptData = prompts.FirstOrDefault(prompt => prompt.Prompt == args.Prompt);
         var defaultResponse = "For real-time prompt processing, connect the AI AssistView component to your preferred AI service, such as OpenAI or Azure Cognitive Services. Ensure you obtain the necessary API credentials to authenticate and enable seamless integration.";
-        args.Response = isPromptFound ? promptData.Response : defaultResponse;
+        args.Response = string.IsNullOrEmpty(promptData.Response) ? defaultResponse : promptData.Response;
     }
 }
 


### PR DESCRIPTION
### Description
Need to resolve the prompts property gets updated with user input, causing PromptRequested logic to always detect existing prompt in Blazor AI assitview issue.

### Screenshot
NA.

### Areas affected and ensured
None

### Test cases
NA

### Test bed sample location
NA

### Additional checklist
- [ ] Did you run the automation against your implementation? NA
- [ ] Is there any API name change? NA.
- [ ] Is there any existing behavior change of other features due to this code change? No
- [x] Does your new code introduce new warnings or binding errors? No
- [ ] Does your code pass all FxCop and StyleCop rules? No
- [ ] Did you record this case in the unit test or UI test? No