### PR TITLE
204953-SEO-Site-Audit-SERPTAT-Blazor-Domain-Description-too-short

### DIFF
--- a/blazor/datagrid/cell.md
+++ b/blazor/datagrid/cell.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Cell in Blazor DataGrid | Syncfusion
-description: Check out this page to learn how to set gridlines, tooltips, styles, and more in cells in the Syncfusion® Blazor DataGrid component.
+description: Check out this page to learn how to set gridlines, tooltips, styles, and more in cells in the Syncfusion Blazor DataGrid component.
 platform: Blazor
 control: DataGrid
 documentation: ug

--- a/blazor/datagrid/cell.md
+++ b/blazor/datagrid/cell.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Cell in Blazor DataGrid | Syncfusion
-description: Checkout and learn here all about the Cell in the Syncfusion Blazor DataGrid and much more.
+description: Check out this page to learn how to set gridlines, tooltips, styles, and more in cells in the Syncfusion® Blazor DataGrid component.
 platform: Blazor
 control: DataGrid
 documentation: ug

--- a/blazor/datagrid/filtering.md
+++ b/blazor/datagrid/filtering.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Filtering in Blazor DataGrid | Syncfusion
-description: Checkout and learn here all about Filtering in Syncfusion Blazor DataGrid and much more details.
+description: Check out this page to learn all about how to configure initial filtering and filter operators in the Syncfusion® Blazor DataGrid component.
 platform: Blazor
 control: DataGrid
 documentation: ug

--- a/blazor/datagrid/filtering.md
+++ b/blazor/datagrid/filtering.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Filtering in Blazor DataGrid | Syncfusion
-description: Check out this page to learn all about how to configure initial filtering and filter operators in the Syncfusion® Blazor DataGrid component.
+description: Check out this page to learn all about how to configure initial filtering and filter operators in the Syncfusion Blazor DataGrid component.
 platform: Blazor
 control: DataGrid
 documentation: ug

--- a/blazor/datagrid/row.md
+++ b/blazor/datagrid/row.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Row in Blazor DataGrid | Syncfusion
-description: Check out this page to learn all about setting row styles, heights, hovering, pinning, and more in the Syncfusion® Blazor DataGrid component.
+description: Check out this page to learn all about setting row styles, heights, hovering, pinning, and more in the Syncfusion Blazor DataGrid component.
 platform: Blazor
 control: DataGrid
 documentation: ug

--- a/blazor/datagrid/row.md
+++ b/blazor/datagrid/row.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Row in Blazor DataGrid | Syncfusion
-description: Checkout and learn here all about Row in Syncfusion Blazor DataGrid and much more details.
+description: Check out this page to learn all about setting row styles, heights, hovering, pinning, and more in the Syncfusion® Blazor DataGrid component.
 platform: Blazor
 control: DataGrid
 documentation: ug


### PR DESCRIPTION
Hi @MallikaRK 

|Title|Description|
|--|--|
|Task Category|Site Audir- SERPSTAT Issue fixes- Blazor Domain-Description too short
|Content Task Link/Mail Screenshot|https://syncfusion-content.bolddesk.com/support/tickets/4364
|UX task| NA|
|Hotfix|https://github.com/syncfusion-content/blazor-docs/pull/6298
|Ticket/Task link|https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/204953/
|Excel/SharePoint link| NA|

|Changes made|Reason for changes|
|--|--|
|Description too short|According to SEO the description should have character count between 100-160
 
Regards,
Mercy A.