### PR TITLE
207727-SEO-Site-Audit-Serpstat-Blazor-Domain-Description-Too-Short

### DIFF
--- a/blazor/datagrid/data-annotation.md
+++ b/blazor/datagrid/data-annotation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Data Annotation in Blazor DataGrid | Syncfusion
-description: Learn how to achieve data validation with data annotations in the Syncfusion® Blazor DataGrid component.
+description: Learn how to achieve data validation with data annotations in the Syncfusion Blazor DataGrid component.
 platform: Blazor
 control: DataGrid
 documentation: ug

--- a/blazor/datagrid/events.md
+++ b/blazor/datagrid/events.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Events in Blazor DataGrid | Syncfusion
-description: Learn all about the events triggered by grid actions in the Syncfusion® Blazor DataGrid component here.
+description: Learn all about the events triggered by grid actions in the Syncfusion Blazor DataGrid component here.
 platform: Blazor
 control: DataGrid
 documentation: ug

--- a/blazor/datagrid/row-template.md
+++ b/blazor/datagrid/row-template.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Row Template in Blazor DataGrid | Syncfusion
-description: Learn how to customize the appearance and layout of rows in the Syncfusion® Blazor DataGrid component using row templates.
+description: Learn how to customize the appearance and layout of rows in the Syncfusion Blazor DataGrid component using row templates.
 platform: Blazor
 control: DataGrid
 documentation: ug

--- a/blazor/datagrid/sorting.md
+++ b/blazor/datagrid/sorting.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Sorting in Blazor DataGrid | Syncfusion
-description: Learn all about sorting data-bound columns, single and multiple, in Syncfusion® Blazor DataGrid component.
+description: Learn all about sorting data-bound columns, single and multiple, in Syncfusion Blazor DataGrid component.
 platform: Blazor
 control: DataGrid
 documentation: ug

--- a/blazor/datagrid/virtual-scrolling.md
+++ b/blazor/datagrid/virtual-scrolling.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Virtualization in Blazor DataGrid | Syncfusion
-description: Learn all about virtualization in the Syncfusion® Blazor DataGrid component, including virtual scrolling and paging.
+description: Learn all about virtualization in the Syncfusion Blazor DataGrid component, including virtual scrolling and paging.
 platform: Blazor
 control: DataGrid
 documentation: ug


### PR DESCRIPTION
 Hi @MallikaRK 

|Title|Description toos short|
|--|--|
|Task Category| Site Audit-FT Description too long
|Content Task Link/Mail Screenshot|https://syncfusion-content.bolddesk.com/support/tickets/4757|
|UX task| NA|
|Hotfix|https://github.com/syncfusion-content/blazor-docs/pull/6458
|Ticket/Task link|https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/207727/
|Excel/SharePoint link|https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7B2953218C-B2D4-4D2B-8E5F-58F63984FD30%7D&file=SERPSTAT%20Issue%20Fixes%20Blazor%20Domain%2020th%20August.xlsx&action=default&mobileredirect=true

|Changes made|Reason for changes|
|--|--|
|Description too short|According to SEO meta description should have character counts that range between 100-160|

Regards,
Mercy A.