### PR TITLE
968285: Added documentation for SelectionChanged event, ExecuteCommand NumberFormat and BulletFormat list

### DIFF
--- a/blazor/rich-text-editor/events.md
+++ b/blazor/rich-text-editor/events.md
@@ -458,6 +458,29 @@ This section explains the list of events of the RichTextEditor component which w
 
 ```
 
+## SelectionChanged
+
+`SelectionChanged` event triggers whenever the selection is modified within the Rich Text Editor.
+
+N> This event does not trigger when the selection range is collapsed (i.e., when only the cursor is placed without any content being selected).
+
+```cshtml
+
+@using Syncfusion.Blazor.RichTextEditor
+
+<SfRichTextEditor>
+    <RichTextEditorEvents SelectionChanged="@SelectionChangedHandler"></RichTextEditorEvents>
+</SfRichTextEditor>
+
+@code {
+    public void SelectionChangedHandler(Syncfusion.Blazor.RichTextEditor.SelectionChangedEventArgs args)
+    {
+        // Here you can customize your code
+    }
+}
+
+```
+
 ## OnResizeStart
 
 `OnResizeStart` event triggers only when resizing the image is started.

--- a/blazor/rich-text-editor/exec-command.md
+++ b/blazor/rich-text-editor/exec-command.md
@@ -212,6 +212,106 @@ await this.RteObj.ExecuteCommandAsync(CommandName.InsertUnorderedList);
 </tr>
 
 <tr>
+<td><p>NumberFormatList - None</p></td>
+<td><p>Create an ordered list without any specific numbering style.</p></td>
+<td>
+{% highlight cshtml %}
+await this.RteObj.ExecuteCommandAsync(CommandName.NumberFormatList, "none");
+{% endhighlight %}</td>
+</tr>
+
+<tr>
+<td><p>NumberFormatList - Number</p></td>
+<td><p>Creates an ordered list using standard Arabic numerals (1, 2, 3...).</p></td>
+<td>
+{% highlight cshtml %}
+await this.RteObj.ExecuteCommandAsync(CommandName.NumberFormatList, "decimal");
+{% endhighlight %}</td>
+</tr>
+
+<tr>
+<td><p>NumberFormatList - Lower alpha</p></td>
+<td><p>Creates an ordered list using lowercase alphabetic characters (a, b, c...).</p></td>
+<td>
+{% highlight cshtml %}
+await this.RteObj.ExecuteCommandAsync(CommandName.NumberFormatList, "lowerAlpha");
+{% endhighlight %}</td>
+</tr>
+
+<tr>
+<td><p>NumberFormatList - Upper alpha</p></td>
+<td><p>Creates an ordered list using uppercase alphabetic characters (A, B, C...).</p></td>
+<td>
+{% highlight cshtml %}
+await this.RteObj.ExecuteCommandAsync(CommandName.NumberFormatList, "upperAlpha");
+{% endhighlight %}</td>
+</tr>
+
+<tr>
+<td><p>NumberFormatList - Lower roman</p></td>
+<td><p>Creates an ordered list using lowercase Roman numerals (i, ii, iii...).</p></td>
+<td>
+{% highlight cshtml %}
+await this.RteObj.ExecuteCommandAsync(CommandName.NumberFormatList, "lowerRoman");
+{% endhighlight %}</td>
+</tr>
+
+<tr>
+<td><p>NumberFormatList - Upper roman</p></td>
+<td><p>Creates an ordered list using uppercase Roman numerals (I, II, III...).</p></td>
+<td>
+{% highlight cshtml %}
+await this.RteObj.ExecuteCommandAsync(CommandName.NumberFormatList, "upperRoman");
+{% endhighlight %}</td>
+</tr>
+
+<tr>
+<td><p>NumberFormatList - Lower greek</p></td>
+<td><p>Creates an ordered list using lowercase Greek letters (α, β, γ...).</p></td>
+<td>
+{% highlight cshtml %}
+await this.RteObj.ExecuteCommandAsync(CommandName.NumberFormatList, "lowerGreek");
+{% endhighlight %}</td>
+</tr>
+
+<tr>
+<td><p>BulletFormatList - None</p></td>
+<td><p>Creates an unordered list without any specific style.</p></td>
+<td>
+{% highlight cshtml %}
+await this.RteObj.ExecuteCommandAsync(CommandName.BulletFormatList, "none");
+{% endhighlight %}</td>
+</tr>
+
+<tr>
+<td><p>BulletFormatList - Disc</p></td>
+<td><p>Creates an unordered list using solid disc bullets (•).</p></td>
+<td>
+{% highlight cshtml %}
+await this.RteObj.ExecuteCommandAsync(CommandName.BulletFormatList, "disc");
+{% endhighlight %}</td>
+</tr>
+
+<tr>
+<td><p>BulletFormatList - Circle</p></td>
+<td><p>Creates an unordered list using hollow circle bullets (○).</p></td>
+<td>
+{% highlight cshtml %}
+await this.RteObj.ExecuteCommandAsync(CommandName.BulletFormatList, "circle");
+{% endhighlight %}</td>
+</tr>
+
+<tr>
+<td><p>BulletFormatList - Square</p></td>
+<td><p>Creates an unordered list using square bullets (▪).</p></td>
+<td>
+{% highlight cshtml %}
+await this.RteObj.ExecuteCommandAsync(CommandName.BulletFormatList, "square");
+{% endhighlight %}</td>
+</tr>
+
+
+<tr>
 <td><p>Outdent</p></td>
 <td><p>Allows you to decrease the content's indentation level.</p></td>
 <td>

--- a/blazor/rich-text-editor/slash-commands.md
+++ b/blazor/rich-text-editor/slash-commands.md
@@ -15,6 +15,8 @@ The slash menu in the Rich Text Editor provides users with an efficient way to a
 
 To enable the slash menu, set the [Enable](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.RichTextEditor.RichTextEditorSlashMenuSettings.html#Syncfusion_Blazor_RichTextEditor_RichTextEditorSlashMenuSettings_Enable) property within [RichTextEditorSlashMenuSettings](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.RichTextEditor.RichTextEditorSlashMenuSettings.html) to `true`. By default, this feature is disabled. Once enabled, the slash menu will appear when the user types the “/” character in the editor.
 
+N> The SlashMenu feature is not supported when enabling iframe mode in the Rich Text Editor.
+
 ## Configure the slash menu items
 
 The [RichTextEditorSlashMenuSettings](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.RichTextEditor.RichTextEditorSlashMenuSettings.html) property allows customization of the `Items` displayed in the slash menu. By setting the [Items](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.RichTextEditor.RichTextEditorSlashMenuSettings.html#Syncfusion_Blazor_RichTextEditor_RichTextEditorSlashMenuSettings_Items) property with a list of [SlashMenuItemModel](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.RichTextEditor.RichTextEditorSlashMenuSettings.html#Syncfusion_Blazor_RichTextEditor_RichTextEditorSlashMenuSettings_SlashMenuItemModel), you can define which commands are available when a user types a slash (/) in the Rich Text Editor.


### PR DESCRIPTION
### Bug description

[968285](https://dev.azure.com/EssentialStudio/Ej2-Web/_workitems/edit/968285) - Update UG Documentation for BulletFormatList and NumberFormatList API Support in both Blazor 

[976488](https://dev.azure.com/EssentialStudio/Ej2-Web/_workitems/edit/976488) - Add UG Documentation for onTextSelection Event Support in Rich Text Editor (HTML Mode) – Blazor

### Root Cause / Analysis

Updated the documentation for newly added features.

### Reason for not identifying earlier

* If any other reason, provide the details here. 

### Is Breaking issue.?

NO

### Is reported by customer in incident/forum.?

NO

### Solution Description

1.Added the documentation for SelectionChanged Event, NumberFormatList and BulletFormatList in ExecuteCommand and updated the Slashmenu feature.

### Areas affected and ensured

No areas were impacted by this change.

### E2E report details against this fix

NA

### Did you included unit test cases.?

No

### Is there any API name changes.?

No

### Reviewer Checklist

* []  All provided information are reviewed and ensured. 