### PR TITLE
764701: Updated corrections in Blazor themes docs

### DIFF
--- a/blazor/appearance/themes.md
+++ b/blazor/appearance/themes.md
@@ -91,7 +91,7 @@ Refer to the comparison below for the default and optimized theme file sizes:
 
 Syncfusion<sup style="font-size:70%">&reg;</sup> Blazor themes can be used in your Blazor application by referencing the style sheet.
 
-*  For **Blazor Web App** or **Blazor Server App**, refer style sheet inside the `<head>` of **~/Components/App.razor** file for .NET 9 or .NET 8.
+*  For **Blazor Web Apps using any render mode (Server, WebAssembly, or Auto)**, refer style sheet inside the `<head>` of **~/Components/App.razor** file.
 * For **Blazor WebAssembly App**, refer style sheet inside the `<head>` of **wwwroot/index.html** file.
 
 Using the below approaches the themes can be referenced in the Blazor application,
@@ -116,7 +116,7 @@ N> For **Blazor Web App with interaction mode as  Auto & Blazor WASM App**, call
 
 Syncfusion<sup style="font-size:70%">&reg;</sup> Blazor themes are available as static web assets in the [Syncfusion.Blazor.Themes](https://www.nuget.org/packages/Syncfusion.Blazor.Themes/) and [Syncfusion.Blazor](https://www.nuget.org/packages/Syncfusion.Blazor/) NuGet Packages.
 
-*  For **Blazor Web App** or **Blazor Server App**,  refer style sheet inside the `<head>` of **~/Components/App.razor** file for .NET 9 or .NET 8.
+*  For **Blazor Web Apps using any render mode (Server, WebAssembly, or Auto)**,  refer style sheet inside the `<head>` of **~/Components/App.razor** file for .NET 9 or .NET 8.
 
 * For **Blazor WebAssembly App**, refer style sheet inside the `<head>` element of **wwwroot/index.html** file.
 
@@ -131,7 +131,7 @@ To refer to optimized CSS files, use the following syntax:
 
  ```html
 <head>
-    <link href="_content/Syncfusion.Blazor.Themes/bootstrap5.lite.css" rel="stylesheet" />
+    <link href="_content/Syncfusion.Blazor.Themes/bootstrap5-lite.css" rel="stylesheet" />
 </head>
 ```
 
@@ -146,7 +146,7 @@ To reference optimized CSS files from [Syncfusion.Blazor](https://www.nuget.org/
 
  ```html
 <head>
-    <link href="_content/Syncfusion.Blazor/styles/bootstrap5.lite.css" rel="stylesheet" />
+    <link href="_content/Syncfusion.Blazor/styles/bootstrap5-lite.css" rel="stylesheet" />
 </head>
 ```
 
@@ -1046,7 +1046,7 @@ In the Blazor application, the application theme can be changed dynamically by c
 
 The following example demonstrates how to change a theme dynamically in Blazor application using Syncfusion<sup style="font-size:70%">&reg;</sup> Blazor themes using Syncfusion<sup style="font-size:70%">&reg;</sup> Dropdown component.
 
-* For **Blazor Web App**, the theme is changed based on query string at the **~/Components/App.razor** file
+* For **Blazor Web Apps using any render mode (Server, WebAssembly, or Auto)**, the theme is changed based on query string at the **~/Components/App.razor** file
 
 {% tabs %}
 {% highlight c# tabtitle=".NET 9 & .NET 8 (~/App.razor)" %}
@@ -1274,7 +1274,7 @@ The following example demonstrates how to change a theme dynamically in Blazor a
 
 N> [View sample in GitHub](https://github.com/SyncfusionExamples/theme-switching-in-blazor-server-app)
 
-### Change theme dynamically in blazor WebAssembly (WASM) app
+### Change theme dynamically in blazor WASM Standalone app
 
 The following example demonstrates how to change a theme dynamically in Blazor WebAssembly using the application with the Syncfusion<sup style="font-size:70%">&reg;</sup> Blazor themes using Syncfusion<sup style="font-size:70%">&reg;</sup> Dropdown component.
 
@@ -1375,8 +1375,8 @@ Material and Tailwind Themes uses online roboto font. If your app is designed to
    ![Customized CSS](images/custom-css-crg.png)
 5. Copy the files under the **customized** folder to Blazor application `~/wwwroot` folder.
 6. Now, manually add the custom styles in the Blazor App to render the components without any issues on the machines that contains no internet access.
-    * For **Blazor Web App** or **Blazor Server App**, reference custom styles in `~/Components/App.razor` file
-    * For **Blazor WASM App**, reference custom styles in `~/wwwroot/index.html` file.
+    * For **Blazor Web Apps using any render mode (Server, WebAssembly, or Auto)**, reference custom styles in `~/Components/App.razor` file
+    * For **Blazor WASM Standalone App**, reference custom styles in `~/wwwroot/index.html` file.
 
 ```html
     <head>

--- a/blazor/appearance/themes.md
+++ b/blazor/appearance/themes.md
@@ -7,7 +7,7 @@ component: Appearance
 documentation: ug
 ---
 
-# Blazor Themes in Syncfusion<sup style="font-size:70%">&reg;</sup> Components
+# Blazor Themes in Syncfusion&reg; Components
 
 The following list of themes are included in the Syncfusion<sup style="font-size:70%">&reg;</sup> Blazor components library.
 


### PR DESCRIPTION
### Description:

**1. Corrected stylesheet path in documentation:** 
Updated bootstrap5.lite.css to bootstrap5-lite.css to reflect the actual static asset path used by the Syncfusion Blazor NuGet package.

**2. Clarified head section location:** 
Updated project type as we have provided least TFM support as .NET8