### PR TITLE
982808: Removed the improper playground samples in 3D Chart and Circular Gauge.

### DIFF
--- a/blazor/3D-chart/working-with-data.md
+++ b/blazor/3D-chart/working-with-data.md
@@ -265,7 +265,6 @@ The following sample code shows how to send parameters using the Query property 
 
 }
 ```
-{% previewsample "https://blazorplayground.syncfusion.com/embed/hDVzNxLfUlNVErCr?appbar=false&editor=false&result=true&errorlist=false&theme=bootstrap5" %}
 
 ## Empty points
 

--- a/blazor/3D-chart/working-with-data.md
+++ b/blazor/3D-chart/working-with-data.md
@@ -207,7 +207,6 @@ The [SfDataManager](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.Data
 </SfChart3D>
 
 ```
-{% previewsample "https://blazorplayground.syncfusion.com/embed/VZhpXnrpAccANHLf?appbar=false&editor=false&result=true&errorlist=false&theme=bootstrap5" %}
 
 ![Blazor 3D Chart with ODataV4Adaptor Binding](images/working-data/blazor-chart-odatav4-adaptor-binding.png)
 

--- a/blazor/circular-gauge/how-to/place-gauge-inside-other-components.md
+++ b/blazor/circular-gauge/how-to/place-gauge-inside-other-components.md
@@ -172,7 +172,6 @@ When you drag and resize the Dashboard Layout panel or resize the window, the Ci
 }
 
 ```
-{% previewsample "https://blazorplayground.syncfusion.com/embed/hDLAirBcqpadhlqd?appbar=false&editor=false&result=true&errorlist=false&theme=bootstrap5" %}
 
 ![Blazor Circular Gauge inside Dashboard Layout component](../images/blazor-circulargauge-with-dashboard-layout.png)
 
@@ -313,7 +312,6 @@ When the Circular Gauge component renders within the Tab component, its renderin
 }
 
 ```
-{% previewsample "https://blazorplayground.syncfusion.com/embed/hjVKMLhwUeZXVtLD?appbar=false&editor=false&result=true&errorlist=false&theme=bootstrap5" %}
 
 ![Blazor Circular Gauge inside Tab component](../images/blazor-circulargauge-with-tab.png)
 

--- a/blazor/circular-gauge/pointers.md
+++ b/blazor/circular-gauge/pointers.md
@@ -327,7 +327,6 @@ You can use image instead of rendering marker shape to denote the pointer value.
     </CircularGaugeAxes>
 </SfCircularGauge>
 ```
-{% previewsample "https://blazorplayground.syncfusion.com/embed/BXhUMLhmgVRVZgdx?appbar=false&editor=false&result=true&errorlist=false&theme=bootstrap5" %}
 
 ![Blazor Circular Gauge with Image Pointer](./images/blazor-circulargauge-pointer-with-image.png)
 

--- a/blazor/circular-gauge/ranges.md
+++ b/blazor/circular-gauge/ranges.md
@@ -353,7 +353,6 @@ To apply linear gradient to the range, follow the below code sample.
     }
 </style>
 ```
-{% previewsample "https://blazorplayground.syncfusion.com/embed/VXBgWrrmqhBbMMDq?appbar=false&editor=false&result=true&errorlist=false&theme=bootstrap5" %}
 
 ### Radial gradient
 
@@ -464,7 +463,6 @@ To apply radial gradient to the range, follow the below code sample.
     }
 </style>
 ```
-{% previewsample "https://blazorplayground.syncfusion.com/embed/LXVqiLLcAhUizuIm?appbar=false&editor=false&result=true&errorlist=false&theme=bootstrap5" %}
 
 ## See also
 


### PR DESCRIPTION
Removed the improper playground samples in 3D Chart and Circular Gauge.