### PR TITLE
820115: level

### DIFF
--- a/blazor-toc.html
+++ b/blazor-toc.html
@@ -5138,6 +5138,7 @@
 			<li> <a href="/blazor/treegrid/context-menu">Context Menu</a></li>
 			<li> <a href="/blazor/treegrid/custom-style">Styling and Appearance</a></li>
 			<li> <a href="/blazor/treegrid/events">Events</a></li>
+			<li> <a href="/blazor/treegrid/performance">Performance Tips</a></li>
 			<li>How To
 				<ul>
 					<li> <a href="/blazor/treegrid/how-to/show-or-hide-columns-in-dialog-editing">Show or Hide columns in Dialog editing</a></li>

--- a/blazor-toc.html
+++ b/blazor-toc.html
@@ -5159,6 +5159,7 @@
 					<li> <a href="/blazor/treegrid/how-to/editing-with-template-column">Editing with template column</a></li>
 					<li> <a href="/blazor/treegrid/how-to/hide-treegrid-header">Hide Tree Grid Header</a></li>
 					<li> <a href="/blazor/treegrid/how-to/display-custom-tool-tip-in-treegrid-cell">Display Custom Tooltip in Tree Grid cell</a></li>
+					<li> <a href="/blazor/treegrid/how-to/collapse-records-on-initial-render">Collapse Records on Initial Render</a></li>
 				</ul>
 			</li>
 			<li>

--- a/blazor/treegrid/custom-toolbar.md
+++ b/blazor/treegrid/custom-toolbar.md
@@ -1,0 +1,465 @@
+````markdown
+---
+layout: post
+title: Custom Toolbar Items in Blazor TreeGrid Component | Syncfusion
+description: Learn how to create and use custom toolbar items in the Syncfusion Blazor TreeGrid, including templates, icons with text, dropdowns, and export actions.
+platform: Blazor
+control: TreeGrid
+documentation: ug
+---
+
+# Custom toolbar in Blazor TreeGrid
+
+The custom toolbar in the Syncfusion<sup style="font-size:70%">&reg;</sup> Blazor TreeGrid enables a distinctive toolbar layout, style, and behavior tailored to application requirements.
+
+Use the `Template` property on `SfToolbar` inside a `ToolbarTemplate` to render custom controls and handle actions in event handlers.
+
+{% tabs %}
+{% highlight razor tabtitle="Index.razor" %}
+@using Syncfusion.Blazor.TreeGrid
+@using Syncfusion.Blazor.Navigations
+@using TreeGridComponent.Data
+
+<SfTreeGrid DataSource="@TreeData" Height="250" @ref="TreeGrid" IdMapping="TaskId" ParentIdMapping="ParentId" TreeColumnIndex="1">
+    <TreeGridTemplates>
+        <ToolbarTemplate>
+            <SfToolbar>
+                <ToolbarEvents Clicked="ToolbarClickHandler"></ToolbarEvents>
+                <ToolbarItems>
+                    <ToolbarItem Type="@ItemType.Button" PrefixIcon="e-chevron-up icon" Id="collapseall" Text="Collapse All"></ToolbarItem>
+                    <ToolbarItem Type="@ItemType.Button" PrefixIcon="e-chevron-down icon" Id="expandall" Text="Expand All"></ToolbarItem>
+                </ToolbarItems>
+            </SfToolbar>
+        </ToolbarTemplate>
+    </TreeGridTemplates>
+    <TreeGridColumns>
+        <TreeGridColumn Field="TaskId" HeaderText="Task ID" Width="120"></TreeGridColumn>
+        <TreeGridColumn Field="TaskName" HeaderText="Task Name" Width="150"></TreeGridColumn>
+        <TreeGridColumn Field="Duration" HeaderText="Duration" Width="130"></TreeGridColumn>
+    </TreeGridColumns>
+</SfTreeGrid>
+
+@code {
+    private SfTreeGrid<BusinessObject> TreeGrid;
+    public List<BusinessObject> TreeData { get; set; }
+
+    protected override void OnInitialized()
+    {
+        TreeData = BusinessObject.GetSelfDataSource();
+    }
+
+    public async Task ToolbarClickHandler(Syncfusion.Blazor.Navigations.ClickEventArgs args)
+    {
+        if (args.Item.Text == "Collapse All")
+        {
+            await TreeGrid.CollapseAllAsync();
+        }
+        if (args.Item.Text == "Expand All")
+        {
+            await TreeGrid.ExpandAllAsync();
+        }
+    }
+}
+{% endhighlight %}
+{% highlight c# tabtitle="BusinessObject.cs" %}
+namespace TreeGridComponent.Data
+{
+    public class BusinessObject
+    {
+        public int TaskId { get; set; }
+        public string TaskName { get; set; }
+        public int? Duration { get; set; }
+        public int? Progress { get; set; }
+        public string Priority { get; set; }
+        public int? ParentId { get; set; }
+
+        public static List<BusinessObject> GetSelfDataSource()
+        {
+            return new List<BusinessObject>
+            {
+                new BusinessObject { TaskId = 1, TaskName = "Parent Task 1", Duration = 10, Progress = 70, Priority = "Critical", ParentId = null },
+                new BusinessObject { TaskId = 2, TaskName = "Child task 1", Progress = 80, Priority = "Low", ParentId = 1 },
+                new BusinessObject { TaskId = 3, TaskName = "Child Task 2", Duration = 5, Progress = 65, Priority = "Critical", ParentId = 2 },
+                new BusinessObject { TaskId = 4, TaskName = "Child task 3", Duration = 6, Priority = "High", Progress = 77, ParentId = 3 }
+            };
+        }
+    }
+}
+{% endhighlight %}
+{% endtabs %}
+
+{% previewsample "https://blazorplayground.syncfusion.com/embed/hXLnjTZEWdcWHjkO?appbar=true&editor=true&result=true&errorlist=true&theme=fluent2" %}
+
+## Render image with text in custom Toolbar
+
+Use a toolbar template to render images and buttons together. Provide alt text for accessibility.
+
+{% tabs %}
+{% highlight razor tabtitle="Index.razor" %}
+@using Syncfusion.Blazor.TreeGrid
+@using Syncfusion.Blazor.Navigations
+@using Syncfusion.Blazor.Buttons
+@using TreeGridComponent.Data
+
+<SfTreeGrid DataSource="@TreeData" Height="250" @ref="TreeGrid" IdMapping="TaskId" ParentIdMapping="ParentId" TreeColumnIndex="1">
+    <TreeGridEditSettings AllowAdding="true" AllowDeleting="true"></TreeGridEditSettings>
+    <SfToolbar>
+        <ToolbarItems>
+            <ToolbarItem Type="ItemType.Input">
+                <Template>
+                    <div class="image-toolbar">
+                        <img src="/images/icon-add.png" alt="Add record" />
+                        <SfButton OnClick="AddRecord">Add</SfButton>
+                        <img src="/images/icon-delete.png" alt="Delete record" />
+                        <SfButton OnClick="DeleteRecord">Delete</SfButton>
+                    </div>
+                </Template>
+            </ToolbarItem>
+        </ToolbarItems>
+    </SfToolbar>
+    <TreeGridColumns>
+        <TreeGridColumn Field="TaskId" HeaderText="Task ID" IsPrimaryKey="true" Width="120"></TreeGridColumn>
+        <TreeGridColumn Field="TaskName" HeaderText="Task Name" Width="150"></TreeGridColumn>
+        <TreeGridColumn Field="Duration" HeaderText="Duration" Width="130"></TreeGridColumn>
+        <TreeGridColumn Field="Progress" HeaderText="Progress" Width="120"></TreeGridColumn>
+    </TreeGridColumns>
+</SfTreeGrid>
+
+@code {
+    private SfTreeGrid<BusinessObject> TreeGrid;
+    public List<BusinessObject> TreeData { get; set; }
+
+    protected override void OnInitialized()
+    {
+        TreeData = BusinessObject.GetSelfDataSource();
+    }
+
+    public async Task AddRecord()
+    {
+        await TreeGrid.AddRecordAsync();
+    }
+
+    public async Task DeleteRecord()
+    {
+        await TreeGrid.DeleteRecordAsync();
+    }
+}
+{% endhighlight %}
+{% highlight c# tabtitle="BusinessObject.cs" %}
+namespace TreeGridComponent.Data
+{
+    public class BusinessObject
+    {
+        public int TaskId { get; set; }
+        public string TaskName { get; set; }
+        public int? Duration { get; set; }
+        public int? Progress { get; set; }
+        public string Priority { get; set; }
+        public int? ParentId { get; set; }
+
+        public static List<BusinessObject> GetSelfDataSource()
+        {
+            return new List<BusinessObject>
+            {
+                new BusinessObject { TaskId = 1, TaskName = "Parent Task 1", Duration = 10, Progress = 70, Priority = "Critical", ParentId = null },
+                new BusinessObject { TaskId = 2, TaskName = "Child task 1", Progress = 80, Priority = "Low", ParentId = 1 },
+                new BusinessObject { TaskId = 3, TaskName = "Child Task 2", Duration = 5, Progress = 65, Priority = "Critical", ParentId = 2 },
+                new BusinessObject { TaskId = 4, TaskName = "Child task 3", Duration = 6, Priority = "High", Progress = 77, ParentId = 3 }
+            };
+        }
+    }
+}
+{% endhighlight %}
+{% endtabs %}
+
+````
+{% previewsample "https://blazorplayground.syncfusion.com/embed/rtVHXpDkCmnRZRLG?appbar=true&editor=true&result=true&errorlist=true&theme=fluent2" %}
+
+## Render SfDropDownList in Custom Toolbar
+
+Rendering an `SfDropDownList` in the custom toolbar extends toolbar functionality and enables tree grid actions based on user selection.
+
+Use the `Template` property inside a `ToolbarItem` to embed the `SfDropDownList`. Bind its `ValueChange` event to a handler method. In the handler, check the selected item value and call the corresponding tree grid method: `StartEditAsync`, `DeleteRecordAsync`, or `EndEditAsync`.
+
+{% tabs %}
+{% highlight razor tabtitle="Index.razor" %}
+@using Syncfusion.Blazor.TreeGrid
+@using Syncfusion.Blazor.Navigations
+@using Syncfusion.Blazor.DropDowns
+@using TreeGridComponent.Data
+
+<SfTreeGrid DataSource="@TreeData" AllowPaging="true" Height="200" @ref="TreeGrid" IdMapping="TaskId" ParentIdMapping="ParentId" TreeColumnIndex="1">
+    <TreeGridEditSettings AllowAdding="true" AllowEditing="true" AllowDeleting="true"></TreeGridEditSettings>
+    <SfToolbar>
+        <ToolbarItems>
+            <ToolbarItem Type="ItemType.Input">
+                <Template>
+                    <label>Change the value: </label>
+                    <SfDropDownList @ref="Dropdown" TValue="string" TItem="SelectItem" DataSource=@LocalData Width="200">
+                        <DropDownListFieldSettings Text="Text" Value="Text"></DropDownListFieldSettings>
+                        <DropDownListEvents TValue="string" TItem="SelectItem" ValueChange="OnChange"></DropDownListEvents>
+                    </SfDropDownList>
+                </Template>
+            </ToolbarItem>
+        </ToolbarItems>
+    </SfToolbar>
+    <TreeGridColumns>
+        <TreeGridColumn Field="TaskId" HeaderText="Task ID" IsPrimaryKey="true" TextAlign="Syncfusion.Blazor.Grids.TextAlign.Right" Width="120"></TreeGridColumn>
+        <TreeGridColumn Field="TaskName" HeaderText="Task Name" Width="150"></TreeGridColumn>
+        <TreeGridColumn Field="Duration" HeaderText="Duration" Width="130"></TreeGridColumn>
+        <TreeGridColumn Field="Progress" HeaderText="Progress" Width="120"></TreeGridColumn>
+    </TreeGridColumns>
+</SfTreeGrid>
+
+@code {
+    private SfDropDownList<string, SelectItem> Dropdown;
+    private SfTreeGrid<BusinessObject> TreeGrid;
+    public List<BusinessObject> TreeData { get; set; }
+
+    public class SelectItem
+    {
+        public string Text { get; set; }
+    }
+
+    List<SelectItem> LocalData = new List<SelectItem>
+    {
+        new SelectItem() { Text = "Edit" },
+        new SelectItem() { Text = "Delete" },
+        new SelectItem() { Text = "Update" },
+    };
+
+    protected override void OnInitialized()
+    {
+        TreeData = BusinessObject.GetSelfDataSource();
+    }
+
+    public async Task OnChange(Syncfusion.Blazor.DropDowns.ChangeEventArgs<string, SelectItem> args)
+    {
+        if (args.ItemData.Text == "Edit")
+        {
+            await this.TreeGrid.StartEditAsync();
+        }
+        if (args.ItemData.Text == "Delete")
+        {
+            await this.TreeGrid.DeleteRecordAsync();
+        }
+        if (args.Value == "Update")
+        {
+            await this.TreeGrid.EndEditAsync();
+        }
+        this.Dropdown.Placeholder = args.ItemData.Text;
+    }
+}
+{% endhighlight %}
+{% highlight c# tabtitle="BusinessObject.cs" %}
+namespace TreeGridComponent.Data
+{
+    public class BusinessObject
+    {
+        public int TaskId { get; set; }
+        public string TaskName { get; set; }
+        public int? Duration { get; set; }
+        public int? Progress { get; set; }
+        public string Priority { get; set; }
+        public int? ParentId { get; set; }
+
+        public static List<BusinessObject> GetSelfDataSource()
+        {
+            return new List<BusinessObject>
+            {
+                new BusinessObject { TaskId = 1, TaskName = "Parent Task 1", Duration = 10, Progress = 70, Priority = "Critical", ParentId = null },
+                new BusinessObject { TaskId = 2, TaskName = "Child task 1", Progress = 80, Priority = "Low", ParentId = 1 },
+                new BusinessObject { TaskId = 3, TaskName = "Child Task 2", Duration = 5, Progress = 65, Priority = "Critical", ParentId = 2 },
+                new BusinessObject { TaskId = 4, TaskName = "Child task 3", Duration = 6, Priority = "High", Progress = 77, ParentId = 3 }
+            };
+        }
+    }
+}
+{% endhighlight %}
+{% endtabs %}
+
+{% previewsample "https://blazorplayground.syncfusion.com/embed/rNhnNJjYMmmaBMkq?appbar=true&editor=true&result=true&errorlist=true&theme=fluent2" %}
+
+## Render SfAutoComplete in Custom Toolbar
+
+Rendering an `SfAutoComplete` in the custom toolbar enables dynamic search based on user input. Bind the `ValueChange` event to a handler that calls the tree grid's `SearchAsync` method to filter records.
+
+{% tabs %}
+{% highlight razor tabtitle="Index.razor" %}
+@using Syncfusion.Blazor.TreeGrid
+@using Syncfusion.Blazor.Navigations
+@using Syncfusion.Blazor.DropDowns
+@using TreeGridComponent.Data
+
+<SfTreeGrid DataSource="@TreeData" AllowPaging="true" @ref="TreeGrid" IdMapping="TaskId" ParentIdMapping="ParentId" TreeColumnIndex="1">
+    <TreeGridPageSettings PageSize="8"></TreeGridPageSettings>
+    <SfToolbar>
+        <ToolbarItems>
+            <ToolbarItem Type="ItemType.Input">
+                <Template>
+                    <SfAutoComplete Placeholder="Search Task Name" TItem="TaskSuggestion" TValue="string" DataSource="@Suggestions">
+                        <AutoCompleteEvents ValueChange="OnSearch" TValue="string" TItem="TaskSuggestion"></AutoCompleteEvents>
+                        <AutoCompleteFieldSettings Value="Name"></AutoCompleteFieldSettings>
+                    </SfAutoComplete>
+                </Template>
+            </ToolbarItem>
+        </ToolbarItems>
+    </SfToolbar>
+    <TreeGridColumns>
+        <TreeGridColumn Field="TaskId" HeaderText="Task ID" TextAlign="Syncfusion.Blazor.Grids.TextAlign.Right" Width="120"></TreeGridColumn>
+        <TreeGridColumn Field="TaskName" HeaderText="Task Name" Width="150"></TreeGridColumn>
+        <TreeGridColumn Field="Duration" HeaderText="Duration" Width="130"></TreeGridColumn>
+        <TreeGridColumn Field="Progress" HeaderText="Progress" Width="120"></TreeGridColumn>
+    </TreeGridColumns>
+</SfTreeGrid>
+
+@code {
+    public class TaskSuggestion
+    {
+        public string Name { get; set; }
+        public int Id { get; set; }
+    }
+
+    List<TaskSuggestion> Suggestions = new List<TaskSuggestion>
+    {
+        new TaskSuggestion() { Name = "Parent Task 1", Id = 1 },
+        new TaskSuggestion() { Name = "Child task 1", Id = 2 },
+        new TaskSuggestion() { Name = "Child Task 2", Id = 3 },
+        new TaskSuggestion() { Name = "Parent Task 2", Id = 4 },
+        new TaskSuggestion() { Name = "Child task 3", Id = 5 }
+    };
+
+    private SfTreeGrid<BusinessObject> TreeGrid;
+    public List<BusinessObject> TreeData { get; set; }
+
+    protected override void OnInitialized()
+    {
+        TreeData = BusinessObject.GetSelfDataSource();
+    }
+
+    public async Task OnSearch(Syncfusion.Blazor.DropDowns.ChangeEventArgs<string, TaskSuggestion> args)
+    {
+        await this.TreeGrid.SearchAsync(args.Value);
+    }
+}
+{% endhighlight %}
+{% highlight c# tabtitle="BusinessObject.cs" %}
+namespace TreeGridComponent.Data
+{
+    public class BusinessObject
+    {
+        public int TaskId { get; set; }
+        public string TaskName { get; set; }
+        public int? Duration { get; set; }
+        public int? Progress { get; set; }
+        public string Priority { get; set; }
+        public int? ParentId { get; set; }
+
+        public static List<BusinessObject> GetSelfDataSource()
+        {
+            return new List<BusinessObject>
+            {
+                new BusinessObject { TaskId = 1, TaskName = "Parent Task 1", Duration = 10, Progress = 70, Priority = "Critical", ParentId = null },
+                new BusinessObject { TaskId = 2, TaskName = "Child task 1", Progress = 80, Priority = "Low", ParentId = 1 },
+                new BusinessObject { TaskId = 3, TaskName = "Child Task 2", Duration = 5, Progress = 65, Priority = "Critical", ParentId = 2 },
+                new BusinessObject { TaskId = 4, TaskName = "Child task 3", Duration = 6, Priority = "High", Progress = 77, ParentId = 3 }
+            };
+        }
+    }
+}
+{% endhighlight %}
+{% endtabs %}
+
+{% previewsample "https://blazorplayground.syncfusion.com/embed/LtLRXJNYswFuQKPS?appbar=true&editor=true&result=true&errorlist=true&theme=fluent2" %}
+
+
+## Render a component or element using the Toolbar Template
+
+Use the `Template` directive inside a `ToolbarItem` to embed any component � buttons, icons, inputs, or other UI elements � and bind event handlers to trigger tree grid actions.
+
+The example below renders export and print buttons in the toolbar. Clicking **Excel Export** calls `ExportToExcelAsync`, **PDF Export** calls `ExportToPdfAsync`, and **Print** calls `PrintAsync`.
+
+N> The styles and layout of image and text in the custom toolbar can be further customized to meet specific design requirements. For better accessibility, always include `alt` text on images.
+
+{% tabs %}
+{% highlight razor tabtitle="Index.razor" %}
+@using Syncfusion.Blazor.TreeGrid
+@using Syncfusion.Blazor.Navigations
+@using Syncfusion.Blazor.Buttons
+@using TreeGridComponent.Data
+
+<SfTreeGrid DataSource="@TreeData" AllowPaging="true" AllowExcelExport="true" AllowPdfExport="true" Height="200" @ref="TreeGrid" IdMapping="TaskId" ParentIdMapping="ParentId" TreeColumnIndex="1">
+    <SfToolbar>
+        <ToolbarItems>
+            <ToolbarItem Type="ItemType.Input">
+                <Template>
+                    <div>
+                        <SfButton OnClick="ExcelExport">Excel Export</SfButton>
+                        <SfButton OnClick="PdfExport">PDF Export</SfButton>
+                        <SfButton OnClick="Print">Print</SfButton>
+                    </div>
+                </Template>
+            </ToolbarItem>
+        </ToolbarItems>
+    </SfToolbar>
+    <TreeGridColumns>
+        <TreeGridColumn Field="TaskId" HeaderText="Task ID" IsPrimaryKey="true" TextAlign="Syncfusion.Blazor.Grids.TextAlign.Right" Width="120"></TreeGridColumn>
+        <TreeGridColumn Field="TaskName" HeaderText="Task Name" Width="150"></TreeGridColumn>
+        <TreeGridColumn Field="Duration" HeaderText="Duration" Width="130"></TreeGridColumn>
+        <TreeGridColumn Field="Progress" HeaderText="Progress" Width="120"></TreeGridColumn>
+    </TreeGridColumns>
+</SfTreeGrid>
+
+@code {
+    private SfTreeGrid<BusinessObject> TreeGrid;
+    public List<BusinessObject> TreeData { get; set; }
+
+    protected override void OnInitialized()
+    {
+        TreeData = BusinessObject.GetSelfDataSource();
+    }
+
+    public async Task ExcelExport()
+    {
+        await this.TreeGrid.ExportToExcelAsync();
+    }
+
+    public async Task PdfExport()
+    {
+        await this.TreeGrid.ExportToPdfAsync();
+    }
+
+    public async Task Print()
+    {
+        await this.TreeGrid.PrintAsync();
+    }
+}
+{% endhighlight %}
+{% highlight c# tabtitle="BusinessObject.cs" %}
+namespace TreeGridComponent.Data
+{
+    public class BusinessObject
+    {
+        public int TaskId { get; set; }
+        public string TaskName { get; set; }
+        public int? Duration { get; set; }
+        public int? Progress { get; set; }
+        public string Priority { get; set; }
+        public int? ParentId { get; set; }
+
+        public static List<BusinessObject> GetSelfDataSource()
+        {
+            return new List<BusinessObject>
+            {
+                new BusinessObject { TaskId = 1, TaskName = "Parent Task 1", Duration = 10, Progress = 70, Priority = "Critical", ParentId = null },
+                new BusinessObject { TaskId = 2, TaskName = "Child task 1", Progress = 80, Priority = "Low", ParentId = 1 },
+                new BusinessObject { TaskId = 3, TaskName = "Child Task 2", Duration = 5, Progress = 65, Priority = "Critical", ParentId = 2 },
+                new BusinessObject { TaskId = 4, TaskName = "Child task 3", Duration = 6, Priority = "High", Progress = 77, ParentId = 3 }
+            };
+        }
+    }
+}
+{% endhighlight %}
+{% endtabs %}
+
+{% previewsample "https://blazorplayground.syncfusion.com/embed/rNrdNTjuWljNshAx?appbar=true&editor=true&result=true&errorlist=true&theme=fluent2" %}

--- a/blazor/treegrid/how-to/collapse-records-on-initial-render.md
+++ b/blazor/treegrid/how-to/collapse-records-on-initial-render.md
@@ -1,0 +1,45 @@
+---
+layout: post
+title: Collapse Records on Initial Render in Blazor TreeGrid | Syncfusion
+description: Learn how to collapse records up to a specific level on initial render in the Syncfusion Blazor TreeGrid component using CollapseAtLevelAsync method.
+platform: Blazor
+control: TreeGrid
+documentation: ug
+---
+
+# Collapse Records on Initial Render in Blazor TreeGrid Component
+
+The Syncfusion Blazor TreeGrid allows you to collapse tree records up to a specific level when the component is first rendered. This is achieved using the [CollapseAtLevelAsync](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.TreeGrid.SfTreeGrid-1.html#Syncfusion_Blazor_TreeGrid_SfTreeGrid_1_CollapseAtLevelAsync_System_Int32_) method, which accepts the level number as a parameter.
+
+To implement this:
+- Bind the [DataBound](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.TreeGrid.TreeGridEvents-1.html#Syncfusion_Blazor_TreeGrid_TreeGridEvents_1_DataBound) event of the TreeGrid using the [TreeGridEvents](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.TreeGrid.TreeGridEvents-1.html) component.
+- In the [DataBound](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.TreeGrid.TreeGridEvents-1.html#Syncfusion_Blazor_TreeGrid_TreeGridEvents_1_DataBound) event handler, invoke the [CollapseAtLevelAsync](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.TreeGrid.SfTreeGrid-1.html#Syncfusion_Blazor_TreeGrid_SfTreeGrid_1_CollapseAtLevelAsync_System_Int32_) method by passing the desired level (e.g., **1** to collapse the first level of records).
+
+> **Note:** The `CollapseAtLevelAsync` method collapses all rows up to and including the specified level. Passing **1** will collapse all first-level parent rows on initial render.
+
+{% tabs %}
+
+{% highlight razor %}
+
+<SfTreeGrid @ref="TreeGrid" DataSource="@TreeData" Height="312" IdMapping="TaskID" ParentIdMapping="ParentID" TreeColumnIndex="1" AllowFiltering="true" AllowSorting Toolbar="@(new List<string>() { "Add", "Delete", "Update", "Cancel", "Search" })">
+    . . . .
+    <TreeGridEvents TValue="TaskData" DataBound="DataBoundHandler"></TreeGridEvents>
+    . . . .
+</SfTreeGrid>
+
+@code {
+    SfTreeGrid<TaskData> TreeGrid;
+    ...
+
+    public void DataBoundHandler(object args)
+    {
+        TreeGrid.CollapseAtLevelAsync(1);
+        // 1 represents the level
+    }
+}
+
+{% endhighlight %}
+
+{% endtabs %}
+
+{% previewsample "https://blazorplayground.syncfusion.com/embed/rjhHNKKMAofdjnkI?appbar=false&editor=false&result=true&errorlist=false&theme=bootstrap5" %}

--- a/blazor/treegrid/how-to/select-children-based-on-parent-selection.md
+++ b/blazor/treegrid/how-to/select-children-based-on-parent-selection.md
@@ -1,0 +1,148 @@
+---
+layout: post
+title: Select Children based on Parent Selection in Blazor TreeGrid | Syncfusion
+description: Learn how to automatically select child records when a parent row is selected in the Syncfusion Blazor TreeGrid component using RowSelecting event.
+platform: Blazor
+control: TreeGrid
+documentation: ug
+---
+
+# Select Children based on Parent Selection in Blazor TreeGrid Component
+
+When a user manually clicks a parent row in the Syncfusion<sup style="font-size:70%">&reg;</sup> Blazor TreeGrid, all its child records can be automatically selected. This is achieved by handling the [RowSelecting](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.TreeGrid.TreeGridEvents-1.html#Syncfusion_Blazor_TreeGrid_TreeGridEvents_1_RowSelecting) event and invoking the [SelectRowsAsync](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.TreeGrid.SfTreeGrid-1.html#Syncfusion_Blazor_TreeGrid_SfTreeGrid_1_SelectRowsAsync_System_Int32___) method.
+
+To implement this:
+- Set the [Type](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.TreeGrid.TreeGridSelectionSettings.html#Syncfusion_Blazor_TreeGrid_TreeGridSelectionSettings_Type) property of [TreeGridSelectionSettings](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.TreeGrid.TreeGridSelectionSettings.html) to **Multiple** and enable [PersistSelection](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.TreeGrid.TreeGridSelectionSettings.html#Syncfusion_Blazor_TreeGrid_TreeGridSelectionSettings_PersistSelection) to retain existing selections across interactions.
+- Bind the [RowSelecting](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.TreeGrid.TreeGridEvents-1.html#Syncfusion_Blazor_TreeGrid_TreeGridEvents_1_RowSelecting) event to detect when the user manually clicks to select a row.
+- In the [RowSelecting](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.TreeGrid.TreeGridEvents-1.html#Syncfusion_Blazor_TreeGrid_TreeGridEvents_1_RowSelecting) event handler, check if the manually selected row is a parent record using the `HasChild` property.
+- Use a recursive helper method (`GetChildren`) to retrieve all nested child records for the selected parent.
+- Invoke [SelectRowsAsync](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.TreeGrid.SfTreeGrid-1.html#Syncfusion_Blazor_TreeGrid_SfTreeGrid_1_SelectRowsAsync_System_Int32___) to select all child records along with the parent row.
+
+{% tabs %}
+
+{% highlight razor %}
+
+@using Syncfusion.Blazor.Grids;
+@using Syncfusion.Blazor.TreeGrid;
+
+<SfTreeGrid @ref="TreeGrid" DataSource="@TreeGridData" IdMapping="TaskId" ParentIdMapping="ParentId" TreeColumnIndex="1">
+    <TreeGridSelectionSettings Type="Syncfusion.Blazor.Grids.SelectionType.Multiple" PersistSelection="true"></TreeGridSelectionSettings>
+    <TreeGridEvents TValue="TreeData.BusinessObject" RowSelecting="RowSelectingHandler"></TreeGridEvents>
+    <TreeGridColumns>
+        <TreeGridColumn Field="TaskId" HeaderText="Task ID" Width="80" TextAlign="Syncfusion.Blazor.Grids.TextAlign.Right"></TreeGridColumn>
+        <TreeGridColumn Field="TaskName" HeaderText="Task Name" Width="160"></TreeGridColumn>
+        <TreeGridColumn Field="Duration" HeaderText="Duration" Width="100" TextAlign="Syncfusion.Blazor.Grids.TextAlign.Right"></TreeGridColumn>
+        <TreeGridColumn Field="Progress" HeaderText="Progress" Width="100" TextAlign="Syncfusion.Blazor.Grids.TextAlign.Right"></TreeGridColumn>
+        <TreeGridColumn Field="Priority" HeaderText="Priority" Width="80"></TreeGridColumn>
+    </TreeGridColumns>
+</SfTreeGrid>
+
+@code {
+    SfTreeGrid<TreeData.BusinessObject> TreeGrid;
+    public List<TreeData.BusinessObject> TreeGridData { get; set; }
+    public List<int> selected_Inx = new List<int>();
+    public bool multiselect = false;
+    public string selectedParentId { get; set; }
+    List<int> childRowIndexes = new List<int>();
+
+    protected override void OnInitialized()
+    {
+        this.TreeGridData = TreeData.GetSelfDataSource().ToList();
+    }
+
+    // Recursively retrieves all child records for a given parent
+    public List<TreeData.BusinessObject> GetChildren(TreeData.BusinessObject parentData)
+    {
+        List<TreeData.BusinessObject> children = new List<TreeData.BusinessObject>();
+        selectedParentId = parentData.TaskId.ToString();
+        var childRecords = TreeGridData.Where(rec => rec.ParentId != null && rec.ParentId.ToString() == parentData.TaskId.ToString()).ToList();
+        for (var i = 0; i < childRecords?.Count; i++)
+        {
+            children.Add(childRecords[i]);
+            var data = childRecords.ElementAt(i);
+            if (data.HasChild)
+            {
+                // Recursively get nested child records
+                children = children.Concat(GetChildren(data)).ToList();
+            }
+        }
+        return children;
+    }
+
+    public async void RowSelectingHandler(Syncfusion.Blazor.Grids.RowSelectingEventArgs<TreeData.BusinessObject> args)
+    {
+        var currentViewData = TreeGrid.GetCurrentViewRecords();
+        var index = currentViewData.IndexOf(args.Data);
+        selected_Inx = selected_Inx.Concat(await TreeGrid.GetSelectedRowIndexesAsync()).Distinct().ToList();
+
+        // Check if the selected row is a parent and has not already been selected via child selection
+        if (args.Data.HasChild && childRowIndexes.IndexOf(index) == -1 && selected_Inx.IndexOf(index) == -1)
+        {
+            // Retrieve all child records for the selected parent
+            var children = GetChildren(args.Data);
+
+            // Collect the row indexes of all child records
+            foreach (var child in children)
+            {
+                childRowIndexes.Add(currentViewData.IndexOf(child));
+            }
+
+            // If Ctrl key is pressed, merge with existing selection; otherwise select only children
+            if (args.IsCtrlPressed)
+            {
+                var selecting_Inx = selected_Inx.Concat(childRowIndexes).ToArray();
+                var inx = selecting_Inx.OrderBy(item => item).ToArray();
+                await TreeGrid.SelectRowsAsync(inx);
+                selected_Inx.Clear();
+            }
+            else
+            {
+                await TreeGrid.SelectRowsAsync(childRowIndexes.ToArray());
+                multiselect = true;
+            }
+
+            childRowIndexes.Clear();
+        }
+    }
+}
+
+{% endhighlight %}
+
+{% highlight c# %}
+
+public class TreeData
+{
+    public class BusinessObject
+    {
+        public Guid TaskId { get; set; }
+        public string TaskName { get; set; }
+        public int? Duration { get; set; }
+        public int? Progress { get; set; }
+        public string Priority { get; set; }
+        public Guid? ParentId { get; set; }
+        public bool HasChild { get; set; }
+    }
+
+    public static List<BusinessObject> GetSelfDataSource()
+    {
+        List<BusinessObject> BusinessObjectCollection = new List<BusinessObject>();
+        BusinessObjectCollection.Add(new BusinessObject() { TaskId = new Guid("284b28db-04b4-401d-9e90-10f911fda1fe"), TaskName = "Parent Task 1", Duration = 1, Progress = 70, Priority = "Critical", ParentId = null, HasChild = true });
+        BusinessObjectCollection.Add(new BusinessObject() { TaskId = new Guid("284b28db-04b4-401d-9e90-10f911fda2fe"), TaskName = "Child task 1", Duration = 2, Progress = 80, Priority = "Low", ParentId = new Guid("284b28db-04b4-401d-9e90-10f911fda1fe"), HasChild = false });
+        BusinessObjectCollection.Add(new BusinessObject() { TaskId = new Guid("284b28db-04b4-401d-9e90-10f911fda5fe"), TaskName = "Parent Task 2", Duration = 5, Progress = 70, Priority = "Critical", ParentId = null, HasChild = true });
+        BusinessObjectCollection.Add(new BusinessObject() { TaskId = new Guid("284b28db-04b4-401d-9e90-10f911fda6fe"), TaskName = "Child task 1", Duration = 4, Progress = 80, Priority = "Critical", ParentId = new Guid("284b28db-04b4-401d-9e90-10f911fda5fe"), HasChild = false });
+        BusinessObjectCollection.Add(new BusinessObject() { TaskId = new Guid("284b28db-04b4-401d-9e90-10f911fda9fe"), TaskName = "Child task 4", Duration = 2, Progress = 77, Priority = "Low", ParentId = new Guid("284b28db-04b4-401d-9e90-10f911fda5fe"), HasChild = false });
+        BusinessObjectCollection.Add(new BusinessObject() { TaskId = new Guid("284b28db-04b4-401d-9e90-10f91fda10fe"), TaskName = "Parent Task 3", Duration = 5, Progress = 70, Priority = "Critical", ParentId = null, HasChild = true });
+        BusinessObjectCollection.Add(new BusinessObject() { TaskId = new Guid("284b28db-04b4-401d-9e90-10f91fda11fe"), TaskName = "Child task 1", Duration = 4, Progress = 80, Priority = "Critical", ParentId = new Guid("284b28db-04b4-401d-9e90-10f91fda10fe"), HasChild = false });
+        BusinessObjectCollection.Add(new BusinessObject() { TaskId = new Guid("284b28db-04b4-401d-9e90-10f91fda15fe"), TaskName = "Child task 4", Duration = 2, Progress = 77, Priority = "Low", ParentId = new Guid("284b28db-04b4-401d-9e90-10f91fda10fe"), HasChild = true });
+        BusinessObjectCollection.Add(new BusinessObject() { TaskId = new Guid("284b28db-04b4-401d-9e90-10f91fda16fe"), TaskName = "Parent Task 3", Duration = 5, Progress = 70, Priority = "Critical", ParentId = new Guid("284b28db-04b4-401d-9e90-10f91fda15fe"), HasChild = true });
+        BusinessObjectCollection.Add(new BusinessObject() { TaskId = new Guid("284b28db-04b4-401d-9e90-10f91fda17fe"), TaskName = "Child task 7", Duration = 4, Progress = 80, Priority = "Critical", ParentId = new Guid("284b28db-04b4-401d-9e90-10f91fda16fe"), HasChild = false });
+        BusinessObjectCollection.Add(new BusinessObject() { TaskId = new Guid("284b28db-04b4-401d-9e90-10f91fda18fe"), TaskName = "Child task 8", Duration = 2, Progress = 77, Priority = "Low", ParentId = new Guid("284b28db-04b4-401d-9e90-10f91fda16fe"), HasChild = false });
+        return BusinessObjectCollection;
+    }
+}
+
+{% endhighlight %}
+
+{% endtabs %}
+
+{% previewsample "https://blazorplayground.syncfusion.com/embed/hjBdDzjiKPmVUGhn?appbar=false&editor=false&result=true&errorlist=false&theme=bootstrap5" %}

--- a/blazor/treegrid/performance.md
+++ b/blazor/treegrid/performance.md
@@ -1,0 +1,122 @@
+---
+layout: post
+title: Performance tips for Blazor TreeGrid Component | Syncfusion
+description: Checkout and learn here all about how to improve the loading performance of Blazor TreeGrid even binding large data set.
+platform: Blazor
+control: TreeGrid
+documentation: ug
+---
+
+# Performance tips for Blazor TreeGrid
+
+This article is a comprehensive guide on improving the loading performance of the Syncfusion<sup style="font-size:70%">&reg;</sup> Blazor TreeGrid, especially when dealing with large datasets along with large number of columns. It provides valuable insights into the steps that need to be followed to bind a large data source without experiencing any performance degradations. By offering detailed explanations and actionable tips, this resource aims to empower readers with the knowledge and best practices necessary to optimize the performance of the Grid during data binding, ensuring a smooth and efficient user experience.
+
+## How to improve loading performance by binding large dataset
+
+In Syncfusion<sup style="font-size:70%">&reg;</sup> Blazor TreeGrid, the framework takes about 0.06 milliseconds to render one component in the page. You can find more details in the official [documentation link](https://learn.microsoft.com/en-us/aspnet/core/blazor/performance?view=aspnetcore-8.0#avoid-thousands-of-component-instances). In Grid each cell(td) is rendered as separate Blazor component so, it is recommended to render only a limited number of rows and columns to guarantee the best loading performance for the component.
+
+### Optimizing performance with paging
+
+To boost the performance efficiency of your application, especially when dealing with large datasets, it is advised to implement paging. [Paging](https://blazor.syncfusion.com/documentation/treegrid/paging) allows you to display TreeGrid data in segmented pages, facilitating easier navigation through substantial datasets. This feature proves particularly beneficial in enhancing the overall performance of your application. For more information on implementing paging, you can refer to the [documentation](https://blazor.syncfusion.com/documentation/treegrid/paging) section dedicated to this feature.
+
+### Optimizing performance with row virtualization or infinite scrolling
+
+To enhance your application's efficiency, especially when dealing with substantial datasets, it is recommended to use [virtualization](https://blazor.syncfusion.com/documentation/treegrid/virtualization). Implementing Virtualization can significantly reduce the load on your application and elevate its overall performance.
+
+1. **Virtualization**: The Virtual scrolling feature in the TreeGrid enables the efficient handling and display of large volumes of data without compromising performance. This approach optimizes the rendering process by loading only the visible rows within the TreeGrid viewport, rather than rendering the entire dataset simultaneously. For more information on implementing row virtualization, you can refer to the [documentation](https://blazor.syncfusion.com/documentation/treegrid/virtualization#row-virtualization) section dedicated to this feature.
+
+### Optimizing performance with column virtualization in large number of columns
+
+[Column virtualization](https://blazor.syncfusion.com/documentation/treegrid/virtualization#column-virtualization) feature in the Syncfusion<sup style="font-size:70%">&reg;</sup> Blazor TreeGrid allows you to optimize the rendering of columns by displaying only the columns that are currently within the viewport. It allows horizontal scrolling to view additional columns. This feature is particularly useful when dealing with TreeGrid that have a large number of columns, as it helps to improve the performance and reduce the initial loading time.
+
+It is possible to enable both row and column virtualization. This feature allows for efficient handling of large datasets by dynamically loading only the visible rows and columns, optimizing performance and enhancing the overall responsiveness of the TreeGrid. For more information on implementing column virtualization, you can refer to the [documentation](https://blazor.syncfusion.com/documentation/treegrid/virtualization#column-virtualization) section dedicated to this feature.
+
+### How to overcome browser height limitation in virtual scrolling
+
+You can load millions of records in the Syncfusion<sup style="font-size:70%">&reg;</sup> Blazor TreeGrid by using virtual scrolling, where the TreeGrid loads and renders rows on-demand while scrolling vertically. As a result, TreeGrid lightens the browser's load by minimizing the DOM elements and rendering elements visible in the viewport. The height of the TreeGrid is calculated using the **Total Records Count * RowHeight** property.
+
+The browser has some maximum pixel height limitations for the scroll bar element. The content placed above the maximum height can't be scrolled if the element height is greater than the browser's maximum height limit. The browser height limit affects the virtual scrolling of the TreeGrid. When a large number of records are bound to the TreeGrid, it can only display the records until the maximum height limit of the browser. Once the browser's height limit is reached while scrolling, the user won't be able to scroll further to view the remaining records.
+
+For example, if the [RowHeight](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.TreeGrid.SfTreeGrid-1.html#Syncfusion_Blazor_TreeGrid_SfTreeGrid_1_RowHeight) is set as 30px and the total record count is 1000000 (1 million), then the height of the TreeGrid element will be 30,000,000 pixels. In this case, the browser's maximum height limit for a div is about 22,369,600 (the maximum pixel height limitation differs for different browsers). The records above the maximum height limit of the browser can't be scrolled.
+
+This height limitation is not related to the TreeGrid. It fully depends on the default behavior of the browser. The same issue is reproduced in the normal HTML table too.
+
+The TreeGrid has an option to overcome this limitation of the browser in the following ways.
+
+**Solution 1: Using RowHeight property**
+
+You can reduce the row height using the [RowHeight](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.TreeGrid.SfTreeGrid-1.html#Syncfusion_Blazor_TreeGrid_SfTreeGrid_1_RowHeight) property of the TreeGrid. It will reduce the overall height to accommodate more rows. But this approach optimizes the limitation, and if the height limit is still reached after reducing the row height, you have to opt for the previous solution or use paging.
+
+**Solution 2: Using paging instead of virtual scrolling**
+
+Similar to virtual scrolling, the paging feature also loads the data in an on-demand concept. Pagination is also compatible with all the other features (Filtering, Editing, etc.) in TreeGrid. So, use the paging feature instead of virtual scrolling to view a large number of records in the TreeGrid without any kind of performance degradation or browser height limitation.
+
+### How to prevent connection disconnected error when loading a large number of columns with enabled persistence
+
+The problem arises specifically when the TreeGrid attempts to set persistent data with a larger number of columns. It is recommended to increase the buffer size of the WebSocket. Check the below provided code snippet added in the `Program.cs` file and official [documentation](https://learn.microsoft.com/en-us/aspnet/core/signalr/configuration?view=aspnetcore-3.0&tabs=dotnet#configure-server-options) link.
+
+```csharp
+builder.Services.AddSignalR(hubOptions =>
+{
+    hubOptions.MaximumReceiveMessageSize = 10 * 1024 * 1024; // 10MB
+});
+```
+
+## How to improve loading performance by binding data from service
+
+1. When binding data to the Syncfusion<sup style="font-size:70%">&reg;</sup> Blazor TreeGrid from a service, it is advisable to set the data source in the TreeGrid [Created](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.TreeGrid.TreeGridEvents-1.html#Syncfusion_Blazor_TreeGrid_TreeGridEvents_1_Created) event instead of the `OnInitializedAsync` method. If you call the data-fetching method within `OnInitializedAsync`, the delay in fetching data from the service can impact the application's startup time and the rendering of the TreeGrid. However, if you assign the data inside the `Created` event, the TreeGrid will have already been created/rendered. Since there are no service request calls inside the `Created` event, you are simply assigning the data already fetched from `OnInitializedAsync` to the TreeGrid's [DataSource](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.TreeGrid.SfTreeGrid-1.html#Syncfusion_Blazor_TreeGrid_SfTreeGrid_1_DataSource) property within the Created event handler.
+
+2. When dealing with a service that returns a large dataset, there is a possibility that the `Created` event might be triggered before the completion of the `OnInitializedAsync`. In such scenarios, it is recommended to employ a custom binding approach for associating data with the TreeGrid. This method enables customization of the displayed data using the `Read/ReadAsync` method. Instead of relying on `OnInitializedAsync`, you can invoke your service within the `Read/ReadAsync` method and provide the data for display in the TreeGrid. For detailed information, refer to the below documentations:
+   * [Custom binding](https://blazor.syncfusion.com/documentation/treegrid/custom-binding)
+   * [Injecting service into CustomAdaptor](https://blazor.syncfusion.com/documentation/treegrid/custom-binding#inject-service-into-custom-adaptor)
+
+## How to improve loading performance by referring individual script and CSS
+
+To improve the performance of Syncfusion<sup style="font-size:70%">&reg;</sup> Blazor TreeGrid during the initial render as well as certain actions, it is suggested to refer to the individual NuGet package (`Syncfusion.Blazor.TreeGrid`) along with its specified script files. In the consolidated package (`Syncfusion.Blazor`) all the components will be defined and hence the size of the package will be more. Along with its script file size being more since scripts necessary for all the Syncfusion<sup style="font-size:70%">&reg;</sup> Blazor components will be defined inside it.
+
+When package and script file size is more, there might be a delay or performance lag in rendering the component in certain specifications compared to TreeGrid rendered using individual scripts and NuGet. Individual NuGet package will contain all the necessary and required dependent component sources along with its script reference. So it is not necessary to refer to the dependent component externally while referring to the individual package.
+
+Refer to the below documentations:
+* [Individual NuGet package](https://blazor.syncfusion.com/documentation/treegrid/getting-started-webapp#install-syncfusion-blazor-treegrid-and-themes-nuget-in-the-app)
+* [Adding script and CSS](https://blazor.syncfusion.com/documentation/treegrid/getting-started-webapp#include-syncfusion-styles-and-scripts)
+
+So to improve the performance of TreeGrid during the initial rendering, it is recommended to refer to the individual NuGet package and scripts.
+
+## How to update cell values without frequent server calls
+
+Efficiently update cell values without the need for frequent server calls, especially beneficial for live update scenarios. Even when the data is initially bound from the server, performing edit operations can be done without triggering a database refresh. Utilize the [SetRowDataAsync](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.TreeGrid.SfTreeGrid-1.html#Syncfusion_Blazor_TreeGrid_SfTreeGrid_1_SetRowDataAsync_System_Object__0_) method to update the TreeGrid without affecting the database. Additionally, you can prevent the built-in edit functionality by setting `args.Cancel` to **true**. If you pass the `preventDataUpdate` argument value as **true** to the `SetRowDataAsync` method, it will prevent the database from updating and only refresh the UI.
+
+```csharp
+public async Task OnClick()
+{
+    var data = new BusinessObject() { TaskId = 2, TaskName = "Test Add", StartDate = new DateTime(2017, 10, 23), Duration = 10, Progress = 70, Priority = "Critical" };
+    await TreeGrid.SetRowDataAsync(2, data);
+}
+```
+
+## How to optimize server-side data operations with adaptors
+
+The Syncfusion<sup style="font-size:70%">&reg;</sup> Blazor TreeGrid provides support for various adaptors (OData, ODataV4, WebAPI, URL, etc.) to facilitate server-side data operations and CRUD functionalities. By leveraging these adaptors along with the [SfDataManager](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.Data.SfDataManager.html) component, you can seamlessly bind remote data sources to the TreeGrid and execute actions. During data operations like filtering, sorting, and paging, the corresponding action queries are generated as per the adaptor's requirements. It is crucial to handle these actions on the application end and return the processed data back to the TreeGrid. Refer to the documentation for comprehensive details. It is worth noting that for efficient data processing, the suggested order for returning processed data to the TreeGrid is as follows:
+
+* Filtering
+* Sorting
+* Aggregates
+* Paging
+
+## Strategic approaches to addressing latency challenges
+
+Understanding the concerns you are facing regarding the lagging responsiveness of the Syncfusion<sup style="font-size:70%">&reg;</sup> Blazor components, your situation has been reviewed, and several factors contributing to this issue have been identified. It is important to note that when using dialog-oriented features like filtering and dialog editing, a call is made from the client to the server to share position details, resulting in some delay if the servers are located in a distant location.
+
+Additionally, potential solutions to mitigate the delay are offered:
+
+**Network Latency**: When the server is in a different region, the increased distance between the client and server leads to higher latency, impacting the responsiveness of client-server communication.
+
+**Solution**: Host the server in a region closer to the majority of your users to reduce network latency. Choosing a server location nearer to your target audience can significantly improve response times.
+
+Considering these factors and implementing the suggested solutions can minimize the delay in client-to-server calls when hosting the server in a different region in your Blazor application. Testing and monitoring performance are crucial to ensuring optimal responsiveness for your users.
+
+For more information and further guidance, refer to the [documentation](https://learn.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/server?view=aspnetcore-8.0) on hosting and deploying Blazor applications.
+
+## Microsoft Excel limitation while exporting millions of records to Excel file format
+
+By default, Microsoft Excel supports only 1,048,576 records in an Excel sheet. Hence it is not possible to export millions of records to Excel. You can refer to the [documentation](https://support.microsoft.com/en-gb/office/excel-specifications-and-limits-1672b34d-7043-467e-8e27-269d656771c3) link for more details on Microsoft Excel specifications and limits. So it is suggested to export the data in CSV (Comma-Separated Values) or other formats that can handle large datasets more efficiently than Excel.

--- a/blazor/treegrid/performance.md
+++ b/blazor/treegrid/performance.md
@@ -7,96 +7,105 @@ control: TreeGrid
 documentation: ug
 ---
 
-# Performance tips for Blazor TreeGrid
+# Performance tips for Blazor TreeGrid Component
 
-This article is a comprehensive guide on improving the loading performance of the Syncfusion<sup style="font-size:70%">&reg;</sup> Blazor TreeGrid, especially when dealing with large datasets along with large number of columns. It provides valuable insights into the steps that need to be followed to bind a large data source without experiencing any performance degradations. By offering detailed explanations and actionable tips, this resource aims to empower readers with the knowledge and best practices necessary to optimize the performance of the Grid during data binding, ensuring a smooth and efficient user experience.
+This article is a comprehensive guide on improving the loading performance of the Syncfusion<sup style="font-size:70%">&reg;</sup> Blazor TreeGrid, especially when dealing with large datasets along with a large number of columns. It provides valuable insights into the steps that need to be followed to bind a large data source without experiencing any performance degradations. By offering detailed explanations and actionable tips, this resource aims to empower readers with the knowledge and best practices necessary to optimize the performance of the TreeGrid during data binding, ensuring a smooth and efficient user experience.
 
 ## How to improve loading performance by binding large dataset
 
-In Syncfusion<sup style="font-size:70%">&reg;</sup> Blazor TreeGrid, the framework takes about 0.06 milliseconds to render one component in the page. You can find more details in the official [documentation link](https://learn.microsoft.com/en-us/aspnet/core/blazor/performance?view=aspnetcore-8.0#avoid-thousands-of-component-instances). In Grid each cell(td) is rendered as separate Blazor component so, it is recommended to render only a limited number of rows and columns to guarantee the best loading performance for the component.
+In Syncfusion<sup style="font-size:70%">&reg;</sup> Blazor TreeGrid, the framework takes about 0.06 milliseconds to render one component in the page. You can find more details in the official [documentation](https://learn.microsoft.com/en-us/aspnet/core/blazor/performance?view=aspnetcore-8.0#avoid-thousands-of-component-instances). In TreeGrid, each cell (td) is rendered as a separate Blazor component, so it is recommended to render only a limited number of rows and columns to guarantee the best loading performance for the component.
 
 ### Optimizing performance with paging
 
-To boost the performance efficiency of your application, especially when dealing with large datasets, it is advised to implement paging. [Paging](https://blazor.syncfusion.com/documentation/treegrid/paging) allows you to display TreeGrid data in segmented pages, facilitating easier navigation through substantial datasets. This feature proves particularly beneficial in enhancing the overall performance of your application. For more information on implementing paging, you can refer to the [documentation](https://blazor.syncfusion.com/documentation/treegrid/paging) section dedicated to this feature.
+To boost the performance efficiency of your application, especially when dealing with large datasets, it is advised to implement paging. [Paging](https://blazor.syncfusion.com/documentation/treegrid/paging) allows you to display TreeGrid data in segmented pages, facilitating easier navigation through substantial datasets. This feature proves particularly beneficial in enhancing the overall performance of your application. For more information on implementing paging, refer to the [paging documentation](https://blazor.syncfusion.com/documentation/treegrid/paging).
 
-### Optimizing performance with row virtualization or infinite scrolling
+### Optimizing performance with row virtualization
 
-To enhance your application's efficiency, especially when dealing with substantial datasets, it is recommended to use [virtualization](https://blazor.syncfusion.com/documentation/treegrid/virtualization). Implementing Virtualization can significantly reduce the load on your application and elevate its overall performance.
+To enhance your application's efficiency, especially when dealing with substantial datasets, it is recommended to use [virtualization](https://blazor.syncfusion.com/documentation/treegrid/virtualization). Implementing virtualization can significantly reduce the load on your application and elevate its overall performance.
 
-1. **Virtualization**: The Virtual scrolling feature in the TreeGrid enables the efficient handling and display of large volumes of data without compromising performance. This approach optimizes the rendering process by loading only the visible rows within the TreeGrid viewport, rather than rendering the entire dataset simultaneously. For more information on implementing row virtualization, you can refer to the [documentation](https://blazor.syncfusion.com/documentation/treegrid/virtualization#row-virtualization) section dedicated to this feature.
+**Virtualization**: The virtual scrolling feature in the TreeGrid enables the efficient handling and display of large volumes of data without compromising performance. This approach optimizes the rendering process by loading only the visible rows within the TreeGrid viewport, rather than rendering the entire dataset simultaneously. For more information on implementing row virtualization, refer to the [row virtualization documentation](https://blazor.syncfusion.com/documentation/treegrid/virtualization#row-virtualization).
 
-### Optimizing performance with column virtualization in large number of columns
+### Optimizing performance with column virtualization
 
-[Column virtualization](https://blazor.syncfusion.com/documentation/treegrid/virtualization#column-virtualization) feature in the Syncfusion<sup style="font-size:70%">&reg;</sup> Blazor TreeGrid allows you to optimize the rendering of columns by displaying only the columns that are currently within the viewport. It allows horizontal scrolling to view additional columns. This feature is particularly useful when dealing with TreeGrid that have a large number of columns, as it helps to improve the performance and reduce the initial loading time.
+The [column virtualization](https://blazor.syncfusion.com/documentation/treegrid/virtualization#column-virtualization) feature in the Syncfusion<sup style="font-size:70%">&reg;</sup> Blazor TreeGrid allows you to optimize the rendering of columns by displaying only the columns that are currently within the viewport. It allows horizontal scrolling to view additional columns. This feature is particularly useful when dealing with a TreeGrid that has a large number of columns, as it helps to improve performance and reduce the initial loading time.
 
-It is possible to enable both row and column virtualization. This feature allows for efficient handling of large datasets by dynamically loading only the visible rows and columns, optimizing performance and enhancing the overall responsiveness of the TreeGrid. For more information on implementing column virtualization, you can refer to the [documentation](https://blazor.syncfusion.com/documentation/treegrid/virtualization#column-virtualization) section dedicated to this feature.
+It is possible to enable both row and column virtualization. This feature allows for efficient handling of large datasets by dynamically loading only the visible rows and columns, optimizing performance and enhancing the overall responsiveness of the TreeGrid. For more information on implementing column virtualization, refer to the [column virtualization documentation](https://blazor.syncfusion.com/documentation/treegrid/virtualization#column-virtualization).
 
 ### How to overcome browser height limitation in virtual scrolling
 
 You can load millions of records in the Syncfusion<sup style="font-size:70%">&reg;</sup> Blazor TreeGrid by using virtual scrolling, where the TreeGrid loads and renders rows on-demand while scrolling vertically. As a result, TreeGrid lightens the browser's load by minimizing the DOM elements and rendering elements visible in the viewport. The height of the TreeGrid is calculated using the **Total Records Count * RowHeight** property.
 
-The browser has some maximum pixel height limitations for the scroll bar element. The content placed above the maximum height can't be scrolled if the element height is greater than the browser's maximum height limit. The browser height limit affects the virtual scrolling of the TreeGrid. When a large number of records are bound to the TreeGrid, it can only display the records until the maximum height limit of the browser. Once the browser's height limit is reached while scrolling, the user won't be able to scroll further to view the remaining records.
+The browser has some maximum pixel height limitations for the scroll bar element. The content placed above the maximum height cannot be scrolled if the element height is greater than the browser's maximum height limit. The browser height limit affects the virtual scrolling of the TreeGrid. When a large number of records are bound to the TreeGrid, it can only display the records until the maximum height limit of the browser. Once the browser's height limit is reached while scrolling, the user will not be able to scroll further to view the remaining records.
 
-For example, if the [RowHeight](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.TreeGrid.SfTreeGrid-1.html#Syncfusion_Blazor_TreeGrid_SfTreeGrid_1_RowHeight) is set as 30px and the total record count is 1000000 (1 million), then the height of the TreeGrid element will be 30,000,000 pixels. In this case, the browser's maximum height limit for a div is about 22,369,600 (the maximum pixel height limitation differs for different browsers). The records above the maximum height limit of the browser can't be scrolled.
+For example, if the [RowHeight](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.TreeGrid.SfTreeGrid-1.html#Syncfusion_Blazor_TreeGrid_SfTreeGrid_1_RowHeight) is set as 30px and the total record count is 1,000,000 (1 million), then the height of the TreeGrid element will be 30,000,000 pixels. In this case, the browser's maximum height limit for a div is about 22,369,600 pixels (the maximum pixel height limitation differs for different browsers). The records above the maximum height limit of the browser cannot be scrolled.
 
-This height limitation is not related to the TreeGrid. It fully depends on the default behavior of the browser. The same issue is reproduced in the normal HTML table too.
+This height limitation is not related to the TreeGrid. It fully depends on the default behavior of the browser. The same issue is reproduced in a normal HTML table as well.
 
-The TreeGrid has an option to overcome this limitation of the browser in the following ways.
+The TreeGrid provides the following options to overcome this browser limitation.
 
 **Solution 1: Using RowHeight property**
 
-You can reduce the row height using the [RowHeight](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.TreeGrid.SfTreeGrid-1.html#Syncfusion_Blazor_TreeGrid_SfTreeGrid_1_RowHeight) property of the TreeGrid. It will reduce the overall height to accommodate more rows. But this approach optimizes the limitation, and if the height limit is still reached after reducing the row height, you have to opt for the previous solution or use paging.
+You can reduce the row height using the [RowHeight](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.TreeGrid.SfTreeGrid-1.html#Syncfusion_Blazor_TreeGrid_SfTreeGrid_1_RowHeight) property of the TreeGrid. It will reduce the overall height to accommodate more rows. If the height limit is still reached after reducing the row height, use paging instead.
 
 **Solution 2: Using paging instead of virtual scrolling**
 
-Similar to virtual scrolling, the paging feature also loads the data in an on-demand concept. Pagination is also compatible with all the other features (Filtering, Editing, etc.) in TreeGrid. So, use the paging feature instead of virtual scrolling to view a large number of records in the TreeGrid without any kind of performance degradation or browser height limitation.
+Similar to virtual scrolling, the paging feature also loads the data in an on-demand concept. Paging is compatible with all other features (Filtering, Editing, etc.) in TreeGrid. Use the paging feature instead of virtual scrolling to view a large number of records in the TreeGrid without any performance degradation or browser height limitation.
 
-### How to prevent connection disconnected error when loading a large number of columns with enabled persistence
+### How to prevent connection disconnected error when loading large number of columns with persistence enabled
 
-The problem arises specifically when the TreeGrid attempts to set persistent data with a larger number of columns. It is recommended to increase the buffer size of the WebSocket. Check the below provided code snippet added in the `Program.cs` file and official [documentation](https://learn.microsoft.com/en-us/aspnet/core/signalr/configuration?view=aspnetcore-3.0&tabs=dotnet#configure-server-options) link.
+The problem arises specifically when the TreeGrid attempts to persist data with a large number of columns. It is recommended to increase the buffer size of the WebSocket. Refer to the following code snippet to be added in the `Program.cs` file and the official [SignalR configuration documentation](https://learn.microsoft.com/en-us/aspnet/core/signalr/configuration?view=aspnetcore-3.0&tabs=dotnet#configure-server-options).
 
-```csharp
+{% tabs %}
+{% highlight c# tabtitle="Program.cs" %}
+
 builder.Services.AddSignalR(hubOptions =>
 {
     hubOptions.MaximumReceiveMessageSize = 10 * 1024 * 1024; // 10MB
 });
-```
+
+{% endhighlight %}
+{% endtabs %}
 
 ## How to improve loading performance by binding data from service
 
-1. When binding data to the Syncfusion<sup style="font-size:70%">&reg;</sup> Blazor TreeGrid from a service, it is advisable to set the data source in the TreeGrid [Created](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.TreeGrid.TreeGridEvents-1.html#Syncfusion_Blazor_TreeGrid_TreeGridEvents_1_Created) event instead of the `OnInitializedAsync` method. If you call the data-fetching method within `OnInitializedAsync`, the delay in fetching data from the service can impact the application's startup time and the rendering of the TreeGrid. However, if you assign the data inside the `Created` event, the TreeGrid will have already been created/rendered. Since there are no service request calls inside the `Created` event, you are simply assigning the data already fetched from `OnInitializedAsync` to the TreeGrid's [DataSource](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.TreeGrid.SfTreeGrid-1.html#Syncfusion_Blazor_TreeGrid_SfTreeGrid_1_DataSource) property within the Created event handler.
+When binding data to the Syncfusion<sup style="font-size:70%">&reg;</sup> Blazor TreeGrid from a service, it is advisable to set the data source in the TreeGrid [Created](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.TreeGrid.TreeGridEvents-1.html#Syncfusion_Blazor_TreeGrid_TreeGridEvents_1_Created) event instead of the `OnInitializedAsync` method. If the data-fetching method is called within `OnInitializedAsync`, the delay in fetching data from the service can impact the application's startup time and the rendering of the TreeGrid. However, if the data is assigned inside the `Created` event, the TreeGrid will have already been created and rendered. Since there are no service request calls inside the `Created` event, the data already fetched from `OnInitializedAsync` is simply assigned to the TreeGrid's [DataSource](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.TreeGrid.SfTreeGrid-1.html#Syncfusion_Blazor_TreeGrid_SfTreeGrid_1_DataSource) property within the `Created` event handler.
 
-2. When dealing with a service that returns a large dataset, there is a possibility that the `Created` event might be triggered before the completion of the `OnInitializedAsync`. In such scenarios, it is recommended to employ a custom binding approach for associating data with the TreeGrid. This method enables customization of the displayed data using the `Read/ReadAsync` method. Instead of relying on `OnInitializedAsync`, you can invoke your service within the `Read/ReadAsync` method and provide the data for display in the TreeGrid. For detailed information, refer to the below documentations:
-   * [Custom binding](https://blazor.syncfusion.com/documentation/treegrid/custom-binding)
-   * [Injecting service into CustomAdaptor](https://blazor.syncfusion.com/documentation/treegrid/custom-binding#inject-service-into-custom-adaptor)
+When dealing with a service that returns a large dataset, there is a possibility that the `Created` event might be triggered before the completion of `OnInitializedAsync`. In such scenarios, it is recommended to use a custom binding approach for associating data with the TreeGrid. This method enables customization of the displayed data using the `Read/ReadAsync` method. Instead of relying on `OnInitializedAsync`, the service can be invoked within the `Read/ReadAsync` method to provide the data for display in the TreeGrid. For detailed information, refer to the following documentation:
 
-## How to improve loading performance by referring individual script and CSS
+* [Custom binding](https://blazor.syncfusion.com/documentation/treegrid/custom-binding)
+* [Inject service into CustomAdaptor](https://blazor.syncfusion.com/documentation/treegrid/custom-binding#inject-service-into-custom-adaptor)
 
-To improve the performance of Syncfusion<sup style="font-size:70%">&reg;</sup> Blazor TreeGrid during the initial render as well as certain actions, it is suggested to refer to the individual NuGet package (`Syncfusion.Blazor.TreeGrid`) along with its specified script files. In the consolidated package (`Syncfusion.Blazor`) all the components will be defined and hence the size of the package will be more. Along with its script file size being more since scripts necessary for all the Syncfusion<sup style="font-size:70%">&reg;</sup> Blazor components will be defined inside it.
+## How to improve loading performance by referring individual NuGet package and script
 
-When package and script file size is more, there might be a delay or performance lag in rendering the component in certain specifications compared to TreeGrid rendered using individual scripts and NuGet. Individual NuGet package will contain all the necessary and required dependent component sources along with its script reference. So it is not necessary to refer to the dependent component externally while referring to the individual package.
+To improve the performance of the Syncfusion<sup style="font-size:70%">&reg;</sup> Blazor TreeGrid during the initial render as well as certain actions, it is recommended to refer to the individual NuGet package (`Syncfusion.Blazor.TreeGrid`) along with its specified script files. In the consolidated package (`Syncfusion.Blazor`), all the components are defined and hence the size of the package is larger. Similarly, the script file size is larger since scripts for all Syncfusion<sup style="font-size:70%">&reg;</sup> Blazor components are defined inside it.
 
-Refer to the below documentations:
+When the package and script file sizes are larger, there may be a delay or performance lag in rendering the component compared to TreeGrid rendered using individual scripts and NuGet. The individual NuGet package contains all the necessary and required dependent component sources along with its script reference, so it is not necessary to refer to dependent components externally.
+
+Refer to the following documentation:
 * [Individual NuGet package](https://blazor.syncfusion.com/documentation/treegrid/getting-started-webapp#install-syncfusion-blazor-treegrid-and-themes-nuget-in-the-app)
 * [Adding script and CSS](https://blazor.syncfusion.com/documentation/treegrid/getting-started-webapp#include-syncfusion-styles-and-scripts)
 
-So to improve the performance of TreeGrid during the initial rendering, it is recommended to refer to the individual NuGet package and scripts.
-
 ## How to update cell values without frequent server calls
 
-Efficiently update cell values without the need for frequent server calls, especially beneficial for live update scenarios. Even when the data is initially bound from the server, performing edit operations can be done without triggering a database refresh. Utilize the [SetRowDataAsync](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.TreeGrid.SfTreeGrid-1.html#Syncfusion_Blazor_TreeGrid_SfTreeGrid_1_SetRowDataAsync_System_Object__0_) method to update the TreeGrid without affecting the database. Additionally, you can prevent the built-in edit functionality by setting `args.Cancel` to **true**. If you pass the `preventDataUpdate` argument value as **true** to the `SetRowDataAsync` method, it will prevent the database from updating and only refresh the UI.
+Cell values can be updated efficiently without the need for frequent server calls, which is especially beneficial for live update scenarios. Even when the data is initially bound from the server, edit operations can be performed without triggering a database refresh. Use the [SetRowDataAsync](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.TreeGrid.SfTreeGrid-1.html#Syncfusion_Blazor_TreeGrid_SfTreeGrid_1_SetRowDataAsync_System_Object__0_) method to update the TreeGrid without affecting the database. Additionally, the built-in edit functionality can be prevented by setting `args.Cancel` to **true**. If the `preventDataUpdate` argument value is passed as **true** to the `SetRowDataAsync` method, it will prevent the database from updating and only refresh the UI.
 
-```csharp
-public async Task OnClick()
-{
-    var data = new BusinessObject() { TaskId = 2, TaskName = "Test Add", StartDate = new DateTime(2017, 10, 23), Duration = 10, Progress = 70, Priority = "Critical" };
-    await TreeGrid.SetRowDataAsync(2, data);
+{% tabs %}
+{% highlight razor %}
+
+@code {
+    public async Task OnClick()
+    {
+        var data = new BusinessObject() { TaskId = 2, TaskName = "Test Add", StartDate = new DateTime(2017, 10, 23), Duration = 10, Progress = 70, Priority = "Critical" };
+        await TreeGrid.SetRowDataAsync(2, data);
+    }
 }
-```
+
+{% endhighlight %}
+{% endtabs %}
 
 ## How to optimize server-side data operations with adaptors
 
-The Syncfusion<sup style="font-size:70%">&reg;</sup> Blazor TreeGrid provides support for various adaptors (OData, ODataV4, WebAPI, URL, etc.) to facilitate server-side data operations and CRUD functionalities. By leveraging these adaptors along with the [SfDataManager](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.Data.SfDataManager.html) component, you can seamlessly bind remote data sources to the TreeGrid and execute actions. During data operations like filtering, sorting, and paging, the corresponding action queries are generated as per the adaptor's requirements. It is crucial to handle these actions on the application end and return the processed data back to the TreeGrid. Refer to the documentation for comprehensive details. It is worth noting that for efficient data processing, the suggested order for returning processed data to the TreeGrid is as follows:
+The Syncfusion<sup style="font-size:70%">&reg;</sup> Blazor TreeGrid provides support for various adaptors (OData, ODataV4, WebAPI, URL, etc.) to facilitate server-side data operations and CRUD functionalities. By leveraging these adaptors along with the [SfDataManager](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.Data.SfDataManager.html) component, remote data sources can be seamlessly bound to the TreeGrid and actions can be executed. During data operations like filtering, sorting, and paging, the corresponding action queries are generated as per the adaptor's requirements. It is crucial to handle these actions on the application end and return the processed data back to the TreeGrid. For efficient data processing, the suggested order for returning processed data to the TreeGrid is as follows:
 
 * Filtering
 * Sorting
@@ -105,18 +114,16 @@ The Syncfusion<sup style="font-size:70%">&reg;</sup> Blazor TreeGrid provides su
 
 ## Strategic approaches to addressing latency challenges
 
-Understanding the concerns you are facing regarding the lagging responsiveness of the Syncfusion<sup style="font-size:70%">&reg;</sup> Blazor components, your situation has been reviewed, and several factors contributing to this issue have been identified. It is important to note that when using dialog-oriented features like filtering and dialog editing, a call is made from the client to the server to share position details, resulting in some delay if the servers are located in a distant location.
-
-Additionally, potential solutions to mitigate the delay are offered:
+When using dialog-oriented features like filtering and dialog editing, a call is made from the client to the server to share position details, which can result in some delay if the servers are located in a distant region. The following factors contribute to this issue and their recommended solutions are listed below.
 
 **Network Latency**: When the server is in a different region, the increased distance between the client and server leads to higher latency, impacting the responsiveness of client-server communication.
 
 **Solution**: Host the server in a region closer to the majority of your users to reduce network latency. Choosing a server location nearer to your target audience can significantly improve response times.
 
-Considering these factors and implementing the suggested solutions can minimize the delay in client-to-server calls when hosting the server in a different region in your Blazor application. Testing and monitoring performance are crucial to ensuring optimal responsiveness for your users.
+Implementing the suggested solution can minimize the delay in client-to-server calls. Testing and monitoring performance are crucial to ensuring optimal responsiveness for users.
 
-For more information and further guidance, refer to the [documentation](https://learn.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/server?view=aspnetcore-8.0) on hosting and deploying Blazor applications.
+For more information, refer to the [documentation on hosting and deploying Blazor applications](https://learn.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/server?view=aspnetcore-8.0).
 
-## Microsoft Excel limitation while exporting millions of records to Excel file format
+## Microsoft Excel limitation while exporting millions of records
 
-By default, Microsoft Excel supports only 1,048,576 records in an Excel sheet. Hence it is not possible to export millions of records to Excel. You can refer to the [documentation](https://support.microsoft.com/en-gb/office/excel-specifications-and-limits-1672b34d-7043-467e-8e27-269d656771c3) link for more details on Microsoft Excel specifications and limits. So it is suggested to export the data in CSV (Comma-Separated Values) or other formats that can handle large datasets more efficiently than Excel.
+By default, Microsoft Excel supports only 1,048,576 records in an Excel sheet. Hence, it is not possible to export millions of records to Excel. Refer to the [Excel specifications and limits documentation](https://support.microsoft.com/en-gb/office/excel-specifications-and-limits-1672b34d-7043-467e-8e27-269d656771c3) for more details. It is recommended to export the data in CSV (Comma-Separated Values) or other formats that can handle large datasets more efficiently than Excel.

--- a/blazor/treegrid/toolbar-items.md
+++ b/blazor/treegrid/toolbar-items.md
@@ -1,0 +1,555 @@
+````markdown
+---
+layout: post
+title: Toolbar Items in Blazor TreeGrid Component | Syncfusion
+description: Learn how to use built-in and custom toolbar items in Syncfusion Blazor TreeGrid, including icons, alignment, tooltips, and handling toolbar actions.
+platform: Blazor
+control: TreeGrid
+documentation: ug
+---
+
+# Toolbar items in Blazor TreeGrid
+
+The Syncfusion<sup style="font-size:70%">&reg;</sup> Blazor TreeGrid offers a flexible toolbar that enables the addition of custom toolbar items or modification of existing ones. The toolbar appears above the TreeGrid, providing convenient access to common actions and custom functionality.
+
+## Built-in Toolbar Items
+
+Built-in toolbar items perform standard TreeGrid actions and can be added by defining the [Toolbar](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.TreeGrid.SfTreeGrid-1.html#Syncfusion_Blazor_TreeGrid_SfTreeGrid_1_Toolbar) property as a collection of predefined item names. These items render with both icon and text.
+
+| Built-in Toolbar Item | Action Description               |
+|-----------------------|----------------------------------|
+| ExpandAll             | Expands all rows                 |
+| CollapseAll           | Collapses all rows              |
+| Add                   | Adds a new record                |
+| Edit                  | Edits the selected record        |
+| Update                | Updates the edited record        |
+| Delete                | Deletes the selected record      |
+| Cancel                | Cancels the edit state           |
+| Search                | Searches records by keyword      |
+| Print                 | Prints the TreeGrid              |
+| ExcelExport           | Exports TreeGrid to Excel        |
+| PdfExport             | Exports TreeGrid to PDF          |
+| WordExport            | Exports TreeGrid to Word         |
+
+{% tabs %}
+{% highlight razor tabtitle="Index.razor" %}
+@using Syncfusion.Blazor.TreeGrid
+@using TreeGridComponent.Data
+
+<SfTreeGrid DataSource="@TreeData" AllowPaging="true" Height="200" @ref="TreeGrid" Toolbar="@ToolbarItems" IdMapping="TaskId" ParentIdMapping="ParentId" TreeColumnIndex="1">
+    <TreeGridColumns>
+        <TreeGridColumn Field="TaskId" HeaderText="Task ID" IsPrimaryKey="true" Width="120"></TreeGridColumn>
+        <TreeGridColumn Field="TaskName" HeaderText="Task Name" Width="150"></TreeGridColumn>
+        <TreeGridColumn Field="Duration" HeaderText="Duration" Width="130"></TreeGridColumn>
+        <TreeGridColumn Field="Progress" HeaderText="Progress" Width="120"></TreeGridColumn>
+        <TreeGridColumn Field="Priority" HeaderText="Priority" Width="100"></TreeGridColumn>
+    </TreeGridColumns>
+</SfTreeGrid>
+
+@code {
+    private SfTreeGrid<BusinessObject> TreeGrid;
+    public string[] ToolbarItems = new string[] { "Search", "Print" };
+    public List<BusinessObject> TreeData { get; set; }
+
+    protected override void OnInitialized()
+    {
+        TreeData = BusinessObject.GetSelfDataSource();
+    }
+}
+{% endhighlight %}
+{% highlight c# tabtitle="BusinessObject.cs" %}
+namespace TreeGridComponent.Data
+{
+    public class BusinessObject
+    {
+        public int TaskId { get; set; }
+        public string TaskName { get; set; }
+        public int? Duration { get; set; }
+        public int? Progress { get; set; }
+        public string Priority { get; set; }
+        public int? ParentId { get; set; }
+
+        public static List<BusinessObject> GetSelfDataSource()
+        {
+            return new List<BusinessObject>
+            {
+                new BusinessObject { TaskId = 1, TaskName = "Parent Task 1", Duration = 10, Progress = 70, Priority = "Critical", ParentId = null },
+                new BusinessObject { TaskId = 2, TaskName = "Child task 1", Progress = 80, Priority = "Low", ParentId = 1 },
+                new BusinessObject { TaskId = 3, TaskName = "Child Task 2", Duration = 5, Progress = 65, Priority = "Critical", ParentId = 2 },
+                new BusinessObject { TaskId = 4, TaskName = "Child task 3", Duration = 6, Priority = "High", Progress = 77, ParentId = 3 }
+            };
+        }
+    }
+}
+{% endhighlight %}
+{% endtabs %}
+
+{% previewsample "https://blazorplayground.syncfusion.com/embed/VNhHjfXYrjbwlvMD?appbar=true&editor=true&result=true&errorlist=true&theme=fluent2" %}
+
+## Custom Toolbar Items
+
+Define custom toolbar items by setting the `Toolbar` property to a collection of `ItemModel` objects and handle actions in the `OnToolbarClick` event.
+
+{% tabs %}
+{% highlight razor tabtitle="Index.razor" %}
+@using Syncfusion.Blazor.TreeGrid
+@using Syncfusion.Blazor.Navigations
+@using TreeGridComponent.Data
+
+<SfTreeGrid DataSource="@TreeData" @ref="TreeGrid" Height="200" Toolbar=@Toolbaritems IdMapping="TaskId" ParentIdMapping="ParentId" TreeColumnIndex="1">
+    <TreeGridEvents OnToolbarClick="ToolbarClickHandler" TValue="BusinessObject"></TreeGridEvents>
+    <TreeGridColumns>
+        <TreeGridColumn Field=@nameof(BusinessObject.TaskId) HeaderText="Task ID" TextAlign="Syncfusion.Blazor.Grids.TextAlign.Right" IsPrimaryKey="true" Width="120"></TreeGridColumn>
+        <TreeGridColumn Field=@nameof(BusinessObject.TaskName) HeaderText="Task Name" Width="150"></TreeGridColumn>
+        <TreeGridColumn Field=@nameof(BusinessObject.Duration) HeaderText="Duration" Width="130"></TreeGridColumn>
+        <TreeGridColumn Field=@nameof(BusinessObject.Progress) HeaderText="Progress" Width="120"></TreeGridColumn>
+        <TreeGridColumn Field=@nameof(BusinessObject.Priority) HeaderText="Priority" Width="100"></TreeGridColumn>
+    </TreeGridColumns>
+</SfTreeGrid>
+
+@code {
+    private SfTreeGrid<BusinessObject> TreeGrid;
+    private List<ItemModel> Toolbaritems = new List<ItemModel>();
+    public List<BusinessObject> TreeData { get; set; }
+
+    protected override void OnInitialized()
+    {
+        TreeData = BusinessObject.GetSelfDataSource();
+        Toolbaritems.Add(new ItemModel() { Text = "Expand all", TooltipText = "Expand all", PrefixIcon = "e-expand" });
+        Toolbaritems.Add(new ItemModel() { Text = "Collapse all", TooltipText = "Collapse all", PrefixIcon = "e-collapse-2", Align = Syncfusion.Blazor.Navigations.ItemAlign.Right });
+    }
+
+    public async Task ToolbarClickHandler(Syncfusion.Blazor.Navigations.ClickEventArgs args)
+    {
+        if (args.Item.Text == "Expand all")
+        {
+            await this.TreeGrid.ExpandAllAsync();
+        }
+        if (args.Item.Text == "Collapse all")
+        {
+            await this.TreeGrid.CollapseAllAsync();
+        }
+    }
+}
+{% endhighlight %}
+{% highlight c# tabtitle="BusinessObject.cs" %}
+namespace TreeGridComponent.Data
+{
+    public class BusinessObject
+    {
+        public int TaskId { get; set; }
+        public string TaskName { get; set; }
+        public int? Duration { get; set; }
+        public int? Progress { get; set; }
+        public string Priority { get; set; }
+        public int? ParentId { get; set; }
+
+        public static List<BusinessObject> GetSelfDataSource()
+        {
+            return new List<BusinessObject>
+            {
+                new BusinessObject { TaskId = 1, TaskName = "Parent Task 1", Duration = 10, Progress = 70, Priority = "Critical", ParentId = null },
+                new BusinessObject { TaskId = 2, TaskName = "Child task 1", Progress = 80, Priority = "Low", ParentId = 1 },
+                new BusinessObject { TaskId = 3, TaskName = "Child Task 2", Duration = 5, Progress = 65, Priority = "Critical", ParentId = 2 },
+                new BusinessObject { TaskId = 4, TaskName = "Child task 3", Duration = 6, Priority = "High", Progress = 77, ParentId = 3 }
+            };
+        }
+    }
+}
+{% endhighlight %}
+{% endtabs %}
+
+{% previewsample "https://blazorplayground.syncfusion.com/embed/BNrnXpNYhDOceKCc?appbar=true&editor=true&result=true&errorlist=true&theme=fluent2" %}
+
+## Both built-in and custom items in Toolbar
+
+You can mix built-in item names (strings) and custom `ItemModel` objects in the `Toolbar` collection.
+
+{% tabs %}
+{% highlight razor tabtitle="Index.razor" %}
+@using Syncfusion.Blazor.TreeGrid
+@using Syncfusion.Blazor.Navigations
+@using TreeGridComponent.Data
+
+<div style="margin-left:280px"><p style="color:red;" id="message">@message</p></div>
+
+<SfTreeGrid DataSource="@TreeData" @ref="TreeGrid" Height="200" Toolbar=@Toolbaritems IdMapping="TaskId" ParentIdMapping="ParentId" TreeColumnIndex="1">
+    <TreeGridEditSettings AllowAdding="true" AllowEditing="true" AllowDeleting="true"></TreeGridEditSettings>
+    <TreeGridEvents OnToolbarClick="ToolbarClickHandler" TValue="BusinessObject"></TreeGridEvents>
+    <TreeGridColumns>
+        <TreeGridColumn Field=@nameof(BusinessObject.TaskId) HeaderText="Task ID" TextAlign="Syncfusion.Blazor.Grids.TextAlign.Right" IsPrimaryKey="true" Width="120"></TreeGridColumn>
+        <TreeGridColumn Field=@nameof(BusinessObject.TaskName) HeaderText="Task Name" Width="150"></TreeGridColumn>
+        <TreeGridColumn Field=@nameof(BusinessObject.Duration) HeaderText="Duration" Width="130"></TreeGridColumn>
+        <TreeGridColumn Field=@nameof(BusinessObject.Progress) HeaderText="Progress" Width="120"></TreeGridColumn>
+        <TreeGridColumn Field=@nameof(BusinessObject.Priority) HeaderText="Priority" Width="100"></TreeGridColumn>
+    </TreeGridColumns>
+</SfTreeGrid>
+
+@code {
+    private SfTreeGrid<BusinessObject> TreeGrid;
+    public string message;
+    private List<object> Toolbaritems = new List<object>() { "Add", "Delete", "Edit", "Update", "Cancel", new ItemModel() { Text = "Click", TooltipText = "Click", PrefixIcon = "e-click", Id = "Click" } };
+    public List<BusinessObject> TreeData { get; set; }
+
+    protected override void OnInitialized()
+    {
+        TreeData = BusinessObject.GetSelfDataSource();
+    }
+
+    public async Task ToolbarClickHandler(Syncfusion.Blazor.Navigations.ClickEventArgs args)
+    {
+        if (args.Item.Text == "Click")
+        {
+            message = "Custom Toolbar Clicked";
+        }
+    }
+}
+{% endhighlight %}
+{% highlight c# tabtitle="BusinessObject.cs" %}
+namespace TreeGridComponent.Data
+{
+    public class BusinessObject
+    {
+        public int TaskId { get; set; }
+        public string TaskName { get; set; }
+        public int? Duration { get; set; }
+        public int? Progress { get; set; }
+        public string Priority { get; set; }
+        public int? ParentId { get; set; }
+
+        public static List<BusinessObject> GetSelfDataSource()
+        {
+            return new List<BusinessObject>
+            {
+                new BusinessObject { TaskId = 1, TaskName = "Parent Task 1", Duration = 10, Progress = 70, Priority = "Critical", ParentId = null },
+                new BusinessObject { TaskId = 2, TaskName = "Child task 1", Progress = 80, Priority = "Low", ParentId = 1 },
+                new BusinessObject { TaskId = 3, TaskName = "Child Task 2", Duration = 5, Progress = 65, Priority = "Critical", ParentId = 2 },
+                new BusinessObject { TaskId = 4, TaskName = "Child task 3", Duration = 6, Priority = "High", Progress = 77, ParentId = 3 }
+            };
+        }
+    }
+}
+{% endhighlight %}
+{% endtabs %}
+
+{% previewsample "https://blazorplayground.syncfusion.com/embed/BZVRZpXkBCKvdwxT?appbar=true&editor=true&result=true&errorlist=true&theme=fluent2" %}
+
+## Customize the text name of custom Toolbar Items with same as default Toolbar Items
+
+If a custom toolbar item uses the same `Text` as a built-in item, assign a unique `Id` so the TreeGrid doesn't treat it as the default item.
+
+{% tabs %}
+{% highlight razor tabtitle="Index.razor" %}
+@using Syncfusion.Blazor.TreeGrid
+@using Syncfusion.Blazor.Navigations
+@using TreeGridComponent.Data
+
+<SfTreeGrid @ref="TreeGrid" DataSource="@TreeData" AllowPaging="true" Toolbar="@ToolbarItems" Height="250" IdMapping="TaskId" ParentIdMapping="ParentId" TreeColumnIndex="1">
+    <TreeGridEditSettings AllowAdding="true" AllowDeleting="true" AllowEditing="true"></TreeGridEditSettings>
+    <TreeGridEvents OnToolbarClick="ToolbarClickHandler" TValue="BusinessObject"></TreeGridEvents>
+    <TreeGridColumns>
+        <TreeGridColumn Field=@nameof(BusinessObject.TaskId) IsPrimaryKey="true" HeaderText="Task ID" TextAlign="Syncfusion.Blazor.Grids.TextAlign.Right" Width="120" />
+        <TreeGridColumn Field=@nameof(BusinessObject.TaskName) HeaderText="Task Name" Width="150" />
+        <TreeGridColumn Field=@nameof(BusinessObject.Duration) HeaderText="Duration" Width="130" />
+        <TreeGridColumn Field=@nameof(BusinessObject.Progress) HeaderText="Progress" Width="120" />
+        <TreeGridColumn Field=@nameof(BusinessObject.Priority) HeaderText="Priority" Width="100" />
+    </TreeGridColumns>
+</SfTreeGrid>
+
+@code {
+    private SfTreeGrid<BusinessObject> TreeGrid;
+    public List<BusinessObject> TreeData { get; set; }
+
+    private List<ItemModel> ToolbarItems = new List<ItemModel>() {
+        new ItemModel() { Text = "Add", PrefixIcon = "e-add", Id = "TreeGrid_add" },
+        new ItemModel() { Text = "Edit", PrefixIcon = "e-edit", Id = "TreeGrid_edit" },
+        new ItemModel() { Text = "Delete", PrefixIcon = "e-delete", Id = "TreeGrid_delete" },
+        new ItemModel() { Text = "Update", PrefixIcon = "e-update", Id = "TreeGrid_update" },
+        new ItemModel() { Text = "Cancel", PrefixIcon = "e-cancel", Id = "TreeGrid_cancel" }
+    };
+
+    protected override void OnInitialized()
+    {
+        TreeData = BusinessObject.GetSelfDataSource();
+    }
+
+    public async Task ToolbarClickHandler(Syncfusion.Blazor.Navigations.ClickEventArgs args)
+    {
+        if (args.Item.Text == "Add")
+        {
+            await TreeGrid.AddRecordAsync();
+        }
+        if (args.Item.Text == "Edit")
+        {
+            await TreeGrid.StartEditAsync();
+        }
+        if (args.Item.Text == "Delete")
+        {
+            await TreeGrid.DeleteRecordAsync();
+        }
+        if (args.Item.Text == "Update")
+        {
+            await TreeGrid.EndEditAsync();
+        }
+        if (args.Item.Text == "Cancel")
+        {
+            await TreeGrid.CloseEditAsync();
+        }
+    }
+}
+{% endhighlight %}
+{% highlight c# tabtitle="BusinessObject.cs" %}
+namespace TreeGridComponent.Data
+{
+    public class BusinessObject
+    {
+        public int TaskId { get; set; }
+        public string TaskName { get; set; }
+        public int? Duration { get; set; }
+        public int? Progress { get; set; }
+        public string Priority { get; set; }
+        public int? ParentId { get; set; }
+
+        public static List<BusinessObject> GetSelfDataSource()
+        {
+            return new List<BusinessObject>
+            {
+                new BusinessObject { TaskId = 1, TaskName = "Parent Task 1", Duration = 10, Progress = 70, Priority = "Critical", ParentId = null },
+                new BusinessObject { TaskId = 2, TaskName = "Child task 1", Progress = 80, Priority = "Low", ParentId = 1 },
+                new BusinessObject { TaskId = 3, TaskName = "Child Task 2", Duration = 5, Progress = 65, Priority = "Critical", ParentId = 2 },
+                new BusinessObject { TaskId = 4, TaskName = "Child task 3", Duration = 6, Priority = "High", Progress = 77, ParentId = 3 }
+            };
+        }
+    }
+}
+{% endhighlight %}
+{% endtabs %}
+
+{% previewsample "https://blazorplayground.syncfusion.com/embed/BNrnXpNYhDOceKCc?appbar=true&editor=true&result=true&errorlist=true&theme=fluent2" %}
+
+## Customizing the toolbar items tooltip text
+
+Set `ItemModel.TooltipText` for custom items to improve accessibility and convey meaning when icons are shown without text.
+
+{% tabs %}
+{% highlight razor tabtitle="Index.razor" %}
+@using Syncfusion.Blazor.TreeGrid
+@using Syncfusion.Blazor.Navigations
+@using TreeGridComponent.Data
+
+<SfTreeGrid ID="TreeGrid" @ref="TreeGrid" DataSource="@TreeData" AllowPaging="true" Toolbar=@ToolbarItems AllowExcelExport="true" AllowPdfExport="true" IdMapping="TaskId" ParentIdMapping="ParentId" TreeColumnIndex="1">
+    <TreeGridEditSettings AllowAdding="true" AllowDeleting="true" AllowEditing="true"></TreeGridEditSettings>
+    <TreeGridEvents OnToolbarClick="ToolbarClickHandler" TValue="BusinessObject"></TreeGridEvents>
+    <TreeGridColumns>
+        <TreeGridColumn Field=@nameof(BusinessObject.TaskId) IsPrimaryKey="true" HeaderText="Task ID" TextAlign="Syncfusion.Blazor.Grids.TextAlign.Right" Width="120"></TreeGridColumn>
+        <TreeGridColumn Field=@nameof(BusinessObject.TaskName) HeaderText="Task Name" Width="150"></TreeGridColumn>
+        <TreeGridColumn Field=@nameof(BusinessObject.Duration) HeaderText="Duration" Width="130"></TreeGridColumn>
+        <TreeGridColumn Field=@nameof(BusinessObject.Progress) HeaderText="Progress" Width="120"></TreeGridColumn>
+        <TreeGridColumn Field=@nameof(BusinessObject.Priority) HeaderText="Priority" Width="100"></TreeGridColumn>
+    </TreeGridColumns>
+</SfTreeGrid>
+
+@code {
+    private SfTreeGrid<BusinessObject> TreeGrid;
+    public List<BusinessObject> TreeData { get; set; }
+    private List<object> ToolbarItems = new List<object>() {
+        new ItemModel() { Text = "Excel", TooltipText = "Export to Excel", PrefixIcon = "e-excelexport", Id = "TreeGrid_excelexport" },
+        new ItemModel() { Text = "Pdf", TooltipText = "Export to PDF", PrefixIcon = "e-pdfexport", Id = "TreeGrid_pdfexport" },
+        new ItemModel() { Text = "CSV", TooltipText = "Export to CSV", PrefixIcon = "e-csvexport", Id = "TreeGrid_csvexport" },
+    };
+
+    protected override void OnInitialized()
+    {
+        TreeData = BusinessObject.GetSelfDataSource();
+    }
+
+    public async Task ToolbarClickHandler(Syncfusion.Blazor.Navigations.ClickEventArgs args)
+    {
+        if (args.Item.Id == "TreeGrid_pdfexport")
+        {
+            await this.TreeGrid.ExportToPdfAsync();
+        }
+        else if (args.Item.Id == "TreeGrid_excelexport")
+        {
+            await TreeGrid.ExportToExcelAsync();
+        }
+        else if (args.Item.Id == "TreeGrid_csvexport")
+        {
+            await TreeGrid.ExportToCsvAsync();
+        }
+    }
+}
+{% endhighlight %}
+{% highlight c# tabtitle="BusinessObject.cs" %}
+namespace TreeGridComponent.Data
+{
+    public class BusinessObject
+    {
+        public int TaskId { get; set; }
+        public string TaskName { get; set; }
+        public int? Duration { get; set; }
+        public int? Progress { get; set; }
+        public string Priority { get; set; }
+        public int? ParentId { get; set; }
+
+        public static List<BusinessObject> GetSelfDataSource()
+        {
+            return new List<BusinessObject>
+            {
+                new BusinessObject { TaskId = 1, TaskName = "Parent Task 1", Duration = 10, Progress = 70, Priority = "Critical", ParentId = null },
+                new BusinessObject { TaskId = 2, TaskName = "Child task 1", Progress = 80, Priority = "Low", ParentId = 1 },
+                new BusinessObject { TaskId = 3, TaskName = "Child Task 2", Duration = 5, Progress = 65, Priority = "Critical", ParentId = 2 },
+                new BusinessObject { TaskId = 4, TaskName = "Child task 3", Duration = 6, Priority = "High", Progress = 77, ParentId = 3 }
+            };
+        }
+    }
+}
+{% endhighlight %}
+{% endtabs %}
+
+{% previewsample "https://blazorplayground.syncfusion.com/embed/htBxtTWKizdBkokh?appbar=true&editor=true&result=true&errorlist=true&theme=fluent2" %}
+
+### Show only icons in built-in Toolbar Items
+
+To show only icons, hide the text part of the buttons using CSS. For accessibility, provide an accessible name by using `TooltipText` or `aria-label`.
+
+{% tabs %}
+{% highlight razor tabtitle="Index.razor" %}
+@using Syncfusion.Blazor.TreeGrid
+@using Syncfusion.Blazor.Navigations
+@using TreeGridComponent.Data
+
+<SfTreeGrid DataSource="@TreeData" IdMapping="TaskId" ParentIdMapping="ParentId" Toolbar=@ToolbarItems TreeColumnIndex="1">
+    <TreeGridColumns>
+        <TreeGridColumn Field=@nameof(BusinessObject.TaskId) HeaderText="Task ID" Width="80" TextAlign="Syncfusion.Blazor.Grids.TextAlign.Right"></TreeGridColumn>
+        <TreeGridColumn Field=@nameof(BusinessObject.TaskName) HeaderText="Task Name" Width="160"></TreeGridColumn>
+        <TreeGridColumn Field=@nameof(BusinessObject.Duration) HeaderText="Duration" Width="100" TextAlign="Syncfusion.Blazor.Grids.TextAlign.Right"></TreeGridColumn>
+        <TreeGridColumn Field=@nameof(BusinessObject.Progress) HeaderText="Progress" Width="100" TextAlign="Syncfusion.Blazor.Grids.TextAlign.Right"></TreeGridColumn>
+        <TreeGridColumn Field=@nameof(BusinessObject.Priority) HeaderText="Priority" Width="80"></TreeGridColumn>
+    </TreeGridColumns>
+</SfTreeGrid>
+
+@code {
+    public List<string> ToolbarItems = new List<string>() { "Search", "Print" };
+    public List<BusinessObject> TreeData { get; set; }
+
+    protected override void OnInitialized()
+    {
+        TreeData = BusinessObject.GetSelfDataSource();
+    }
+}
+
+<style>
+    .e-treegrid .e-toolbar .e-tbar-btn-text,
+    .e-treegrid .e-toolbar .e-toolbar-items .e-toolbar-item .e-tbar-btn-text {
+        display: none;
+    }
+</style>
+{% endhighlight %}
+{% highlight c# tabtitle="BusinessObject.cs" %}
+namespace TreeGridComponent.Data
+{
+    public class BusinessObject
+    {
+        public int TaskId { get; set; }
+        public string TaskName { get; set; }
+        public int? Duration { get; set; }
+        public int? Progress { get; set; }
+        public string Priority { get; set; }
+        public int? ParentId { get; set; }
+
+        public static List<BusinessObject> GetSelfDataSource()
+        {
+            return new List<BusinessObject>
+            {
+                new BusinessObject { TaskId = 1, TaskName = "Parent Task 1", Duration = 10, Progress = 70, Priority = "Critical", ParentId = null },
+                new BusinessObject { TaskId = 2, TaskName = "Child task 1", Progress = 80, Priority = "Low", ParentId = 1 },
+                new BusinessObject { TaskId = 3, TaskName = "Child Task 2", Duration = 5, Progress = 65, Priority = "Critical", ParentId = 2 },
+                new BusinessObject { TaskId = 4, TaskName = "Child task 3", Duration = 6, Priority = "High", Progress = 77, ParentId = 3 }
+            };
+        }
+    }
+}
+{% endhighlight %}
+{% endtabs %}
+
+{% previewsample "https://blazorplayground.syncfusion.com/embed/BDLxXziUrNjwYslp?appbar=true&editor=true&result=true&errorlist=true&theme=fluent2" %}
+
+## Customize the built-in toolbar items
+
+Handle the `OnToolbarClick` event to intercept actions. Prefer checking `args.Item.Id` for reliability.
+
+{% tabs %}
+{% highlight razor tabtitle="Index.razor" %}
+@using Syncfusion.Blazor.TreeGrid
+@using Syncfusion.Blazor.Navigations
+@using TreeGridComponent.Data
+
+<SfTreeGrid @ref="TreeGrid" DataSource="@TreeData" IdMapping="TaskId" ParentIdMapping="ParentId" TreeColumnIndex="1" Height="315" Toolbar="@Toolbaritems">
+    <TreeGridEvents OnToolbarClick="ToolbarClickHandler" TValue="BusinessObject"></TreeGridEvents>
+    <TreeGridColumns>
+        <TreeGridColumn Field=@nameof(BusinessObject.TaskId) IsPrimaryKey="true" HeaderText="Task ID" TextAlign="Syncfusion.Blazor.Grids.TextAlign.Right" Width="120"></TreeGridColumn>
+        <TreeGridColumn Field=@nameof(BusinessObject.TaskName) HeaderText="Task Name" Width="150"></TreeGridColumn>
+        <TreeGridColumn Field=@nameof(BusinessObject.Duration) HeaderText="Duration" Width="130"></TreeGridColumn>
+        <TreeGridColumn Field=@nameof(BusinessObject.Progress) HeaderText="Progress" Width="120"></TreeGridColumn>
+        <TreeGridColumn Field=@nameof(BusinessObject.Priority) HeaderText="Priority" Width="100"></TreeGridColumn>
+    </TreeGridColumns>
+</SfTreeGrid>
+
+@code {
+    private SfTreeGrid<BusinessObject> TreeGrid;
+    private List<object> Toolbaritems = new List<object>()
+    {
+        "Search",
+        new ItemModel() { Text = "Expand all", TooltipText = "Expand all", PrefixIcon = "e-expand", Align = Syncfusion.Blazor.Navigations.ItemAlign.Left },
+        new ItemModel() { Text = "Collapse all", TooltipText = "Collapse all", PrefixIcon = "e-collapse", Align = Syncfusion.Blazor.Navigations.ItemAlign.Right }
+    };
+    public List<BusinessObject> TreeData { get; set; }
+
+    protected override void OnInitialized()
+    {
+        TreeData = BusinessObject.GetSelfDataSource();
+    }
+
+    public async Task ToolbarClickHandler(Syncfusion.Blazor.Navigations.ClickEventArgs args)
+    {
+        if (args.Item.Text == "Expand all")
+        {
+            await this.TreeGrid.ExpandAllAsync();
+        }
+        if (args.Item.Text == "Collapse all")
+        {
+            await this.TreeGrid.CollapseAllAsync();
+        }
+    }
+}
+{% endhighlight %}
+{% highlight c# tabtitle="BusinessObject.cs" %}
+namespace TreeGridComponent.Data
+{
+    public class BusinessObject
+    {
+        public int TaskId { get; set; }
+        public string TaskName { get; set; }
+        public int? Duration { get; set; }
+        public int? Progress { get; set; }
+        public string Priority { get; set; }
+        public int? ParentId { get; set; }
+
+        public static List<BusinessObject> GetSelfDataSource()
+        {
+            return new List<BusinessObject>
+            {
+                new BusinessObject { TaskId = 1, TaskName = "Parent Task 1", Duration = 10, Progress = 70, Priority = "Critical", ParentId = null },
+                new BusinessObject { TaskId = 2, TaskName = "Child task 1", Progress = 80, Priority = "Low", ParentId = 1 },
+                new BusinessObject { TaskId = 3, TaskName = "Child Task 2", Duration = 5, Progress = 65, Priority = "Critical", ParentId = 2 },
+                new BusinessObject { TaskId = 4, TaskName = "Child task 3", Duration = 6, Priority = "High", Progress = 77, ParentId = 3 }
+            };
+        }
+    }
+}
+{% endhighlight %}
+{% endtabs %}
+
+````
+{% previewsample "https://blazorplayground.syncfusion.com/embed/LjrdjzsUBLqHruIY?appbar=true&editor=true&result=true&errorlist=true&theme=fluent2" %}

--- a/blazor/treegrid/toolbar.md
+++ b/blazor/treegrid/toolbar.md
@@ -15,25 +15,6 @@ To learn more about toolbar templates in the Blazor TreeGrid component, refer to
 
 {% youtube "youtube:https://www.youtube.com/watch?v=yqp_Ukr_aQs" %}
 
-## Built-in Toolbar Items
-
-Built-in toolbar items perform standard TreeGrid actions and can be added by defining the [Toolbar](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.TreeGrid.SfTreeGrid-1.html#Syncfusion_Blazor_TreeGrid_SfTreeGrid_1_Toolbar) property as a collection of predefined item names. These items render with both icon and text.
-
-| Built-in Toolbar Item | Action Description               |
-|-----------------------|----------------------------------|
-| ExpandAll             | Expands all rows                 |
-| CollapseAll           | Collapses all rows              |
-| Add                   | Adds a new record                |
-| Edit                  | Edits the selected record        |
-| Update                | Updates the edited record        |
-| Delete                | Deletes the selected record      |
-| Cancel                | Cancels the edit state           |
-| Search                | Searches records by keyword      |
-| Print                 | Prints the TreeGrid              |
-| ExcelExport           | Exports TreeGrid to Excel        |
-| PdfExport             | Exports TreeGrid to PDF          |
-| WordExport            | Exports TreeGrid to Word         |
-
 {% tabs %}
 
 {% highlight razor %}
@@ -106,11 +87,12 @@ N> The [Toolbar](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor~Syncfus
 
 Toolbar items can be enabled or disabled using the [EnableToolbarItemsAsync](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.TreeGrid.SfTreeGrid-1.html#Syncfusion_Blazor_TreeGrid_SfTreeGrid_1_EnableToolbarItemsAsync_System_Collections_Generic_List_System_String__System_Boolean_) method.
 
-```cshtml
-
+{% tabs %}
+{% highlight razor tabtitle="Index.razor" %}
+@using TreeGridComponent.Data
+@using Syncfusion.Blazor.TreeGrid
 @using Syncfusion.Blazor.Buttons
-@using Syncfusion.Blazor.TreeGrid;
-@using Syncfusion.Blazor.Grids;
+@using Syncfusion.Blazor.Grids
 
 <div>
     <div style="float:left;">
@@ -122,11 +104,11 @@ Toolbar items can be enabled or disabled using the [EnableToolbarItemsAsync](htt
 </div>
 
 @{
-    var Tool = (new string[] { "ExpandAll", "CollapseAll" });
+    var tool = (new string[] { "ExpandAll", "CollapseAll" });
 }
 
-<SfTreeGrid ID="TreeGrid" @ref="TreeGrid" DataSource="TreeGridData" IdMapping="TaskId" ParentIdMapping="ParentId" TreeColumnIndex="1" Toolbar="@Tool" Height="350">
-    <TreeGridEvents TValue="TreeData" OnToolbarClick="ToolBarClick"></TreeGridEvents>
+<SfTreeGrid ID="TreeGrid" @ref="TreeGrid" DataSource="TreeGridData" IdMapping="TaskId" ParentIdMapping="ParentId" TreeColumnIndex="1" Toolbar="@tool" Height="350">
+    <TreeGridEvents OnToolbarClick="ToolBarClick"></TreeGridEvents>
     <TreeGridColumns>
         <TreeGridColumn Field="TaskId" HeaderText="Task ID" Width="80" TextAlign="TextAlign.Right"></TreeGridColumn>
         <TreeGridColumn Field="TaskName" HeaderText="Task Name" Width="145"></TreeGridColumn>
@@ -135,87 +117,105 @@ Toolbar items can be enabled or disabled using the [EnableToolbarItemsAsync](htt
         <TreeGridColumn Field="Priority" HeaderText="Priority" Width="100" TextAlign="TextAlign.Right"></TreeGridColumn>
     </TreeGridColumns>
 </SfTreeGrid>
+{% endhighlight %}
+{% highlight c# tabtitle="Index.razor.cs" %}
+private SfTreeGrid<TreeData> TreeGrid;
+public List<TreeData> TreeGridData { get; set; }
 
-@code{
-    SfTreeGrid<TreeData> TreeGrid;
-
-    public void Enable()
-    {
-        this.TreeGrid.EnableToolbarItemsAsync(new List<string>() { "TreeGrid_gridcontrol_ExpandAll", "TreeGrid_gridcontrol_CollapseAll" }, true);
-    }
-
-    public void Disable()
-    {
-        this.TreeGrid.EnableToolbarItemsAsync(new List<string>() { "TreeGrid_gridcontrol_ExpandAll", "TreeGrid_gridcontrol_CollapseAll" }, false);
-    }
-
-    public void ToolBarClick(Syncfusion.Blazor.Navigations.ClickEventArgs Args)
-    {
-        if (Args.Item.Text == "ExpandAll")
-        {
-            this.TreeGrid.ExpandAll();
-        }
-        if (Args.Item.Text == "CollapseAll")
-        {
-            this.TreeGrid.CollapseAllAsync();
-        }
-    }
-
-    public List<TreeData> TreeGridData { get; set; }
-    public class TreeData
-    {
-        public int TaskId { get; set; }
-        public string TaskName { get; set; }
-        public int? Duration { get; set; }
-        public int? Progress { get; set; }
-        public string Priority { get; set; }
-        public int? ParentId { get; set; }
-        public static List<TreeData> GetSelfDataSource()
-        {
-            List<TreeData> TreeDataCollection = new List<TreeData>();
-            TreeDataCollection.Add(new TreeData(){ TaskId = 1, TaskName = "Parent Task 1", Duration = 10, Progress = 70, Priority = "Critical", ParentId = null });
-            TreeDataCollection.Add(new TreeData(){ TaskId = 2, TaskName = "Child task 1", Progress = 80, Priority = "Low", Duration = 50, ParentId = 1 });
-            TreeDataCollection.Add(new TreeData(){ TaskId = 3, TaskName = "Child Task 2", Duration = 5, Progress = 65, Priority = "Critical", ParentId = 2 });
-            TreeDataCollection.Add(new TreeData(){ TaskId = 4, TaskName = "Child task 3", Duration = 6, Priority = "High", Progress = 77, ParentId = 3 });
-            TreeDataCollection.Add(new TreeData(){ TaskId = 5, TaskName = "Parent Task 2", Duration = 10, Progress = 70, Priority = "Critical", ParentId = null });
-            TreeDataCollection.Add(new TreeData(){ TaskId = 6, TaskName = "Child task 1", Duration = 4, Progress = 80, Priority = "Critical", ParentId = 5 });
-            TreeDataCollection.Add(new TreeData(){ TaskId = 7, TaskName = "Child Task 2", Duration = 5, Progress = 65, Priority = "Low", ParentId = 5 });
-            TreeDataCollection.Add(new TreeData(){ TaskId = 8, TaskName = "Child task 3", Duration = 6, Progress = 77, Priority = "High", ParentId = 5 });
-            TreeDataCollection.Add(new TreeData(){ TaskId = 9, TaskName = "Child task 4", Duration = 6, Progress = 77, Priority = "Low", ParentId = 5 });
-            return TreeDataCollection;
-        }
-    }
-    protected override void OnInitialized()
-    {
-        this.TreeGridData = TreeData.GetSelfDataSource().ToList();
-    }
+protected override void OnInitialized()
+{
+    this.TreeGridData = TreeData.GetSelfDataSource().ToList();
 }
 
-```
+public async Task Enable()
+{
+    await this.TreeGrid.EnableToolbarItemsAsync(new List<string>() { "TreeGrid_gridcontrol_ExpandAll", "TreeGrid_gridcontrol_CollapseAll" }, true);
+}
+
+public async Task Disable()
+{
+    await this.TreeGrid.EnableToolbarItemsAsync(new List<string>() { "TreeGrid_gridcontrol_ExpandAll", "TreeGrid_gridcontrol_CollapseAll" }, false);
+}
+
+public void ToolBarClick(Syncfusion.Blazor.Navigations.ClickEventArgs Args)
+{
+    if (Args.Item.Text == "ExpandAll")
+    {
+        this.TreeGrid.ExpandAll();
+    }
+    if (Args.Item.Text == "CollapseAll")
+    {
+        this.TreeGrid.CollapseAllAsync();
+    }
+}
+{% endhighlight %}
+{% endtabs %}
 
 The following screenshots represent a TreeGrid with Enable/disable toolbar items,
 ![Enabling or Disabling Toolbar Items in Blazor TreeGrid](images/blazor-treegrid-enable-disable-toolbar-items.png)
 
-<!--
-Custom toolbar items
 
-Custom toolbar items can be added by defining the [`Toolbar`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor~Syncfusion.Blazor.TreeGrid.SfTreeGrid~Toolbar.html) as a collection of
-**ItemModels**.
-Actions for this customized toolbar items are defined in the [`ToolbarClick`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor~Syncfusion.Blazor.TreeGrid.SfTreeGrid~ToolbarClick.html) event.
+## Customize Toolbar buttons using CSS
 
-By default, Custom toolbar items are in position **Left**. Change the position by using the **Align** property. In the below sample, we have applied position **Right** for the **Quick Filter** toolbar item.
+Customize the appearance of built-in toolbar buttons by applying CSS to update icon and button backgrounds. When hiding text, ensure accessible names using `TooltipText` or `aria-label`.
 
-> The [`Toolbar`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor~Syncfusion.Blazor.TreeGrid.SfTreeGrid~Toolbar.html) has options to define both built-in and custom toolbar items.
-> If a toolbar item does not match the built-in items, it will be treated as a custom toolbar item.
+{% tabs %}
+{% highlight razor tabtitle="Index.razor" %}
+@page "/"
 
- Built-in and custom items in toolbar
+@using Syncfusion.Blazor.Inputs
+@using Syncfusion.Blazor.TreeGrid
+@using Syncfusion.Blazor.Navigations
 
-TreeGrid have an option to use both built-in and custom toolbar items at same time.
+<SfTreeGrid DataSource="@TreeData" IdMapping="TaskId" ParentIdMapping="ParentId" Toolbar=@ToolbarItems TreeColumnIndex="1">
+    <TreeGridColumns>
+        <TreeGridColumn Field="TaskId" HeaderText="Task ID" Width="80" TextAlign="Syncfusion.Blazor.Grids.TextAlign.Right"></TreeGridColumn>
+        <TreeGridColumn Field="TaskName" HeaderText="Task Name" Width="160"></TreeGridColumn>
+        <TreeGridColumn Field="Duration" HeaderText="Duration" Width="100" TextAlign="Syncfusion.Blazor.Grids.TextAlign.Right"></TreeGridColumn>
+        <TreeGridColumn Field="Progress" HeaderText="Progress" Width="100" TextAlign="Syncfusion.Blazor.Grids.TextAlign.Right"></TreeGridColumn>
+        <TreeGridColumn Field="Priority" HeaderText="Priority" Width="80"></TreeGridColumn>
+    </TreeGridColumns>
+</SfTreeGrid>
 
-In the below example, **ExpandAll**, **CollapseAll** are built-in toolbar items and **Click** is custom toolbar item.
+@code {
+    public List<string> ToolbarItems = new List<string>() { "Search", "Print" };
+    public class BusinessObject
+    {
+        public int TaskId { get; set; }
+        public string TaskName { get; set; }
+        public int Duration { get; set; }
+        public int Progress { get; set; }
+        public string Priority { get; set; }
+        public int? ParentId { get; set; }
+    }
 
-Enable/disable toolbar items
+    public List<BusinessObject> TreeData = new List<BusinessObject>();
 
-Toolbar items can be enabled or disabled using the **enableItems** method.
+    protected override void OnInitialized()
+    {
+        TreeData.Add(new BusinessObject() { TaskId = 1, TaskName = "Parent Task 1", Duration = 10, Progress = 70, ParentId = null, Priority = "High" });
+        TreeData.Add(new BusinessObject() { TaskId = 2, TaskName = "Child task 1", Duration = 4, Progress = 80, ParentId = 1, Priority = "Normal" });
+        TreeData.Add(new BusinessObject() { TaskId = 3, TaskName = "Child Task 2", Duration = 5, Progress = 65, ParentId = 1, Priority = "Critical" });
+        TreeData.Add(new BusinessObject() { TaskId = 4, TaskName = "Parent Task 2", Duration = 6, Progress = 77, ParentId = null, Priority = "Low" });
+        TreeData.Add(new BusinessObject() { TaskId = 5, TaskName = "Child Task 5", Duration = 9, Progress = 25, ParentId = 4, Priority = "Normal" });
+        TreeData.Add(new BusinessObject() { TaskId = 6, TaskName = "Child Task 6", Duration = 9, Progress = 7, ParentId = 5, Priority = "Normal" });
+        TreeData.Add(new BusinessObject() { TaskId = 7, TaskName = "Parent Task 3", Duration = 4, Progress = 45, ParentId = null, Priority = "High" });
+        TreeData.Add(new BusinessObject() { TaskId = 8, TaskName = "Child Task 7", Duration = 3, Progress = 38, ParentId = 7, Priority = "Critical" });
+        TreeData.Add(new BusinessObject() { TaskId = 9, TaskName = "Child Task 8", Duration = 7, Progress = 70, ParentId = 7, Priority = "Low" });
+    }
+}
 
--->
+<style>
+    .e-treegrid .e-toolbar .e-tbar-btn .e-icons,
+    .e-treegrid .e-toolbar .e-toolbar-items .e-toolbar-item .e-tbar-btn {
+        background: #add8e6;
+    }
+</style>
+{% endhighlight %}
+{% endtabs %}
+
+{% previewsample "https://blazorplayground.syncfusion.com/embed/rthdtTZLKnIyYStJ?appbar=true&editor=true&result=true&errorlist=true&theme=fluent2" %}
+
+
+N> Place styles in the component's `.razor.css` when using CSS isolation.
+


### PR DESCRIPTION
## Description
Added new how-to documentation for collapsing records at a specific level on initial render in the Blazor TreeGrid component using the CollapseAtLevelAsync method with the DataBound event.

## Code Studio usage(Mandatory)
- Code Studio used in this PR/MR?
    - [ ] Yes
    - [X] No
- If `Yes`: Primary use (choose one)
    - [ ] Generate new content
    - [ ] Refactor/improve existing content
    - [ ] Review assistance (explanations/summaries)
    - [ ] Other:

- Outcome
    - [ ] Saved time
    - [ ] Neutral
    - [ ] Cost time
- If “Cost time” explain in short (1 or 2 lines):

Changes Made

Documents how to use CollapseAtLevelAsync(1) inside the DataBound event handler to collapse level 1 records on initial render
Includes a Blazor Playground preview sample link

## Type of Change
- [ ] New documentation page
- [X] Update to existing documentation
- [ ] Bug fix (broken links, typos, formatting issues)
- [ ] Structural change (folders, navigation, index)
- [ ] Content improvement (clarity, examples, screenshots)
- [ ] Other (please describe):

## Reviewer Checklist (Mandatory)
- [ ] Reviewed the provided Code Studio usages related information
- [ ] Content changes follow UG/Documentation guidelines
- [ ] All provided information reviewed and verified
- [ ] Links and previews checked

