### PR TITLE
Documentation(1019522): Grid column width Revamp

### DIFF
--- a/blazor/datagrid/columns.md
+++ b/blazor/datagrid/columns.md
@@ -158,15 +158,19 @@ The Blazor DataGrid supports the following three types of column width:
 
 **1. Auto**
 
-The column width is automatically calculated based on the content within its cells. If the content exceeds the `Width` setting, it is truncated with an ellipsis (...).
+The column width is automatically calculated based on the content within the column cells. If the content exceeds the specified width in the `GridColumn`, it is truncated with an ellipsis (…) at the end. To allow a column to adjust its width dynamically based on content, set the Width property of the `GridColumn` to "auto".
+
+A Grid can combine both flexible and fixed-width columns to create a balanced layout. For example, consider three columns: "Order ID", "Customer Name", and "Freight". The "Customer Name" column automatically adjusts its width based on the length of the names, while the "Order ID" and "Freight" columns remain fixed. This ensures that numeric fields stay consistent while text fields expand as needed.
 
 ```cshtml
- <GridColumn Field=@nameof(Order.OrderID) HeaderText="Order ID" TextAlign="TextAlign.Right" Width="auto"></GridColumn>
+<GridColumn Field="@nameof(Order.OrderID)" HeaderText="Order ID" Width="120" TextAlign="TextAlign.Right" />
+<GridColumn Field="@nameof(Order.CustomerName)" HeaderText="Customer Name" Width="auto" />
+<GridColumn Field="@nameof(Order.Freight)" HeaderText="Freight" Width="100" Format="C2" TextAlign="TextAlign.Right" />
 ```
 
 **2. Percentage**
 
-The column width is specified as a **percentage** of the Grid container's total width. For example, `25%` occupies 25% of the Grid `Width`.
+Column width can be defined as a **percentage** relative to the total width of the grid container. For example, assigning `25%` to a column will allocate one-fourth of the grid’s width to that column. This approach is useful for distributing space proportionally across columns.
 
 ```cshtml
  <GridColumn Field=@nameof(Order.OrderID) HeaderText="Order ID" TextAlign="TextAlign.Right" Width="25%"></GridColumn>
@@ -174,7 +178,7 @@ The column width is specified as a **percentage** of the Grid container's total 
 
 **3. Pixel**
 
-The column width is specified as an absolute **pixel** value. For example, a column width of `100px` will have a fixed width of 100 pixels, regardless of the Grid container's size.
+The column width can be defined using an absolute **pixel** value. For example, setting a column width to `100px` means the column will always occupy “100” pixels, regardless of the grid container’s size. The width for `GridColumn` can be set as pixels in the Grid configuration as shown below:
 
 ```cshtml
  <GridColumn Field=@nameof(Order.OrderID) HeaderText="Order ID" TextAlign="TextAlign.Right" Width="100"></GridColumn>


### PR DESCRIPTION
Enhanced the explanation of column width types in the Blazor DataGrid documentation, providing clearer details on auto, percentage, and pixel widths. Added examples for better understanding.

## Description
Provide a clear description of the documentation change.  
Explain **what** was updated, added, or removed.

## Code Studio usage(Mandatory)
- Code Studio used in this PR/MR?
    - [ ] Yes
    - [ ] No
- If `Yes`: Primary use (choose one)
    - [ ] Generate new content
    - [ ] Refactor/improve existing content
    - [ ] Review assistance (explanations/summaries)
    - [ ] Other:

- Outcome
    - [ ] Saved time
    - [ ] Neutral
    - [ ] Cost time
- If “Cost time” explain in short (1 or 2 lines):

## Type of Change
- [ ] New documentation page
- [ ] Update to existing documentation
- [ ] Bug fix (broken links, typos, formatting issues)
- [ ] Structural change (folders, navigation, index)
- [ ] Content improvement (clarity, examples, screenshots)
- [ ] Other (please describe):

## Reviewer Checklist (Mandatory)
- [ ] Reviewed the provided Code Studio usages related information
- [ ] Content changes follow UG/Documentation guidelines
- [ ] All provided information reviewed and verified
- [ ] Links and previews checked

