### PR TITLE
1034249: Removed canonical urls

### DIFF
--- a/blazor/diagram/getting-started-with-maui-app.md
+++ b/blazor/diagram/getting-started-with-maui-app.md
@@ -5,7 +5,6 @@ description: Checkout and learn about the documentation for getting started with
 platform: Blazor
 control: Diagram Component
 documentation: ug
-canonical_url: "https://www.syncfusion.com/blazor-components/blazor-diagram"
 ---
 
 # Getting Started with the Diagram Component in the Blazor MAUI App

--- a/blazor/diagram/getting-started-with-wasm-app.md
+++ b/blazor/diagram/getting-started-with-wasm-app.md
@@ -5,7 +5,6 @@ description: Checkout and learn about the documentation for getting started with
 platform: Blazor
 control: Diagram Component
 documentation: ug
-canonical_url: "https://www.syncfusion.com/blazor-components/blazor-diagram"
 ---
 
 # Getting Started with Diagram Component in the Blazor WASM App

--- a/blazor/diagram/getting-started-with-web-app.md
+++ b/blazor/diagram/getting-started-with-web-app.md
@@ -5,7 +5,6 @@ description: Checkout and learn about the documentation for getting started with
 platform: Blazor
 component: Diagram
 documentation: ug
-canonical_url: "https://www.syncfusion.com/blazor-components/blazor-diagram"
 ---
 
 # Getting Started with Blazor Diagram Component in Web App

--- a/blazor/diagram/getting-started.md
+++ b/blazor/diagram/getting-started.md
@@ -5,7 +5,6 @@ description: Checkout and learn about the documentation for getting started with
 platform: Blazor
 control: Diagram Component
 documentation: ug
-canonical_url: "https://www.syncfusion.com/blazor-components/blazor-diagram"
 ---
 
 # Getting Started with Diagram Component in the Blazor Server App.

--- a/blazor/diagram/overview.md
+++ b/blazor/diagram/overview.md
@@ -5,7 +5,6 @@ description: Checkout and learn here all the features and Overview of the Blazor
 platform: Blazor
 control: Diagram Component
 documentation: ug
-canonical_url: "https://www.syncfusion.com/blazor-components/blazor-diagram"
 ---
 
 # Diagram Component Overview


### PR DESCRIPTION
## Description
Removed Canonical URL as FT link in Getting Started UGs

## Code Studio usage(Mandatory)
- Code Studio used in this PR/MR?
    - [ ] Yes
    - [ ] No
- If `Yes`: Primary use (choose one)
    - [ ] Generate new content
    - [ ] Refactor/improve existing content
    - [ ] Review assistance (explanations/summaries)
    - [ ] Other:

- Outcome
    - [ ] Saved time
    - [ ] Neutral
    - [ ] Cost time
- If “Cost time” explain in short (1 or 2 lines):

## Type of Change
- [ ] New documentation page
- [ ] Update to existing documentation
- [ ] Bug fix (broken links, typos, formatting issues)
- [ ] Structural change (folders, navigation, index)
- [ ] Content improvement (clarity, examples, screenshots)
- [ ] Other (please describe):

## Reviewer Checklist (Mandatory)
- [ ] Reviewed the provided Code Studio usages related information
- [ ] Content changes follow UG/Documentation guidelines
- [ ] All provided information reviewed and verified
- [ ] Links and previews checked

