### PR TITLE
Documentation(1028071): Resolved the low word count issue in the file manager ug documentation

### DIFF
--- a/blazor/file-manager/drag-and-drop.md
+++ b/blazor/file-manager/drag-and-drop.md
@@ -11,35 +11,177 @@ documentation: ug
 
 The File Manager allows files and folders to be moved within the file system by drag and dropping them. This support can be enabled or disabled using the [AllowDragAndDrop](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.FileManager.SfFileManager-1.html#Syncfusion_Blazor_FileManager_SfFileManager_1_AllowDragAndDrop) property of the File Manager.
 
-To disable multiple file selection and enable drag-drop operations in a Blazor File Manager component, you can check on this video.
+To disable multiple file selection and enable drag-drop operations in a Blazor File Manager component, check on this video.
 
 {% youtube
 "youtube:https://www.youtube.com/watch?v=KU3RwdzDvJ0" %}
-
-The events which trigger when using drag and drop functionality are listed below.
-
-* [`OnFileDragStart`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.FileManager.FileManagerEvents-1.html#Syncfusion_Blazor_FileManager_FileManagerEvents_1_OnFileDragStart) - Triggers when the file/folder dragging is started.
-* [`OnFileDragStop`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.FileManager.FileManagerEvents-1.html#Syncfusion_Blazor_FileManager_FileManagerEvents_1_OnFileDragStop) - Triggers when the file/folder is about to be dropped at the target.
-* [`FileDropped`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.FileManager.FileManagerEvents-1.html#Syncfusion_Blazor_FileManager_FileManagerEvents_1_FileDropped) - Triggers when the file/folder is dropped.
 
 ```cshtml
 
 @using Syncfusion.Blazor.FileManager
 
 <SfFileManager AllowDragAndDrop="true" TValue="FileManagerDirectoryContent">
-    <FileManagerAjaxSettings  Url="/api/SampleData/FileOperations"
-                                UploadUrl="/api/SampleData/Upload"
-                                DownloadUrl="/api/SampleData/Download"
-                                GetImageUrl="/api/SampleData/GetImage">
+    <FileManagerAjaxSettings Url="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/FileOperations"
+                             UploadUrl="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/Upload"
+                             DownloadUrl="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/Download"
+                             GetImageUrl="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/GetImage">
     </FileManagerAjaxSettings>
 </SfFileManager>
 
 ```
-
 ## Output
 
-After successful compilation of your application, simply press `F5` to run the application.
+After successful compilation of the application, simply press `F5` to run the application.
 
+![Drag and Drop in Blazor FileManager](images/blazor-filemanager-drag-and-drop.gif)
 
+## Events
 
-![Drag and Drop in Blazor FileManager](images/blazor-filemanager-drag-and-drop.webp)
+The File Manager component provides three key events that allow monitoring and controlling the drag and drop workflow. These events fire at different stages of the operation, enabling implementation of custom validation and business logic.
+
+### OnFileDragStart Event
+
+The [`OnFileDragStart`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.FileManager.FileManagerEvents-1.html#Syncfusion_Blazor_FileManager_FileManagerEvents_1_OnFileDragStart) event fires when the user initiates a drag operation on files or folders. This event can be used to validate dragged items or prevent specific files from being dragged by setting the `Cancel` property to **true**.
+
+```cshtml
+@using Syncfusion.Blazor.FileManager
+
+<SfFileManager TValue="FileManagerDirectoryContent" AllowDragAndDrop="true">
+    <FileManagerAjaxSettings Url="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/FileOperations"
+                             UploadUrl="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/Upload"
+                             DownloadUrl="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/Download"
+                             GetImageUrl="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/GetImage">
+    </FileManagerAjaxSettings>
+    <FileManagerEvents TValue="FileManagerDirectoryContent" OnFileDragStart="OnFileDragStart">
+    </FileManagerEvents>
+</SfFileManager>
+
+@code {
+    public void OnFileDragStart(FileDragEventArgs<FileManagerDirectoryContent> args)
+    {
+        // Here, customize the code as needed.
+    }
+}
+```
+
+### OnFileDragStop Event
+
+The [`OnFileDragStop`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.FileManager.FileManagerEvents-1.html#Syncfusion_Blazor_FileManager_FileManagerEvents_1_OnFileDragStop) event fires when the user is about to drop files or folders at the target location. This event allows to validate the target destination and cancel the operation if needed by setting `Cancel` to **true**.
+
+```cshtml
+@using Syncfusion.Blazor.FileManager
+
+<SfFileManager TValue="FileManagerDirectoryContent" AllowDragAndDrop="true">
+    <FileManagerAjaxSettings Url="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/FileOperations"
+                             UploadUrl="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/Upload"
+                             DownloadUrl="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/Download"
+                             GetImageUrl="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/GetImage">
+    </FileManagerAjaxSettings>
+    <FileManagerEvents TValue="FileManagerDirectoryContent" OnFileDragStop="OnFileDragStop">
+    </FileManagerEvents>
+</SfFileManager>
+
+@code {
+    public void OnFileDragStop(FileDragEventArgs<FileManagerDirectoryContent> args)
+    {
+        // Here, customize the code as needed.
+    }
+}
+```
+
+### FileDropped Event
+
+The [`FileDropped`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.FileManager.FileManagerEvents-1.html#Syncfusion_Blazor_FileManager_FileManagerEvents_1_FileDropped) event fires after a successful drag and drop operation. This event allows to execute post-operation actions after files or folders have been successfully moved.
+
+```cshtml
+@using Syncfusion.Blazor.FileManager
+
+<SfFileManager TValue="FileManagerDirectoryContent" AllowDragAndDrop="true">
+    <FileManagerAjaxSettings Url="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/FileOperations"
+                             UploadUrl="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/Upload"
+                             DownloadUrl="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/Download"
+                             GetImageUrl="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/GetImage">
+    </FileManagerAjaxSettings>
+    <FileManagerEvents TValue="FileManagerDirectoryContent" FileDropped="FileDropped">
+    </FileManagerEvents>
+</SfFileManager>
+
+@code {
+    public void FileDropped(FileDragEventArgs<FileManagerDirectoryContent> args)
+    {
+        // Here, customize the code as needed.
+    }
+}
+```
+## Drag and Drop with Navigation Pane
+
+The File Manager allows you to drag files and folders from the main layout area and drop them into folders displayed in the navigation pane. This feature provides an efficient way to organize and move files across different directory structures without navigating through multiple levels. When you drag an item from the file layout and hover over a folder in the navigation pane, that folder is highlighted to indicate it is a valid drop target. Release the mouse button to complete the move operation.
+
+## Drag and Drop with Breadcrumb Navigation
+
+The File Manager supports dragging and dropping files directly onto the breadcrumb navigation path. When you drag a file from the layout area and drop it on any folder in the breadcrumb path, the file is immediately moved to that target folder. This feature is particularly useful for moving files up the directory hierarchy or to sibling folders without extensive navigation through multiple directory levels.
+
+For example, if you are currently viewing `~/Documents/Projects/2024`, you can drag a file and drop it directly on the breadcrumb segments like `Documents` or `Projects` to move the file to those locations. After the drop operation completes, the file is automatically placed in the appropriate folder according to your drop target selection. This seamless workflow significantly improves file management efficiency.
+
+## Preventing Drag and Drop in the Drag Start Event
+
+The [`OnFileDragStart`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.FileManager.FileManagerEvents-1.html#Syncfusion_Blazor_FileManager_FileManagerEvents_1_OnFileDragStart) event can be used to prevent dragging of specific folders. This is useful when you want to restrict users from moving specific files or folders. By setting the `Cancel` property to **true**, you can prevent the drag operation before it starts.
+
+The following example demonstrates how to prevent dragging of the "Documents" folder:
+
+```cshtml
+@using Syncfusion.Blazor.FileManager
+
+<SfFileManager TValue="FileManagerDirectoryContent" AllowDragAndDrop="true">
+    <FileManagerAjaxSettings Url="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/FileOperations"
+                             UploadUrl="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/Upload"
+                             DownloadUrl="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/Download"
+                             GetImageUrl="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/GetImage">
+    </FileManagerAjaxSettings>
+    <FileManagerEvents TValue="FileManagerDirectoryContent" OnFileDragStart="OnFileDragStart">
+    </FileManagerEvents>
+</SfFileManager>
+
+@code {
+    public void OnFileDragStart(FileDragEventArgs<FileManagerDirectoryContent> args)
+    {
+        if (args.FileDetails[0].Name == "Documents")
+        {
+            // Prevent dragging from the Documents folder
+            args.Cancel = true;
+        } 
+    }
+}
+```
+
+## Preventing Drag and Drop Based on Drop Target
+
+The [`OnFileDragStop`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.FileManager.FileManagerEvents-1.html#Syncfusion_Blazor_FileManager_FileManagerEvents_1_OnFileDragStop) event fires just before the drop operation completes, allowing you to validate the target destination. This is useful when you want to prevent dropping files into specific folders based on business logic or permission rules. By setting the `Cancel` property to **true** in this event, you can cancel the drop operation at the target location.
+
+The following example demonstrates how to prevent dropping items into the "Music" folder:
+
+```cshtml
+@using Syncfusion.Blazor.FileManager
+
+<SfFileManager TValue="FileManagerDirectoryContent" AllowDragAndDrop="true">
+    <FileManagerAjaxSettings Url="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/FileOperations"
+                             UploadUrl="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/Upload"
+                             DownloadUrl="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/Download"
+                             GetImageUrl="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/GetImage">
+    </FileManagerAjaxSettings>
+    <FileManagerEvents TValue="FileManagerDirectoryContent" OnFileDragStop="OnFileDragStop">
+    </FileManagerEvents>
+</SfFileManager>
+
+@code {
+    public void OnFileDragStop(FileDragEventArgs<FileManagerDirectoryContent> args)
+    {
+        // Check the target folder path where items are being dropped
+        if(args.DropTargetDetail.Name == "Music")
+        {
+            // Prevent dropping into the Music folder
+            args.Cancel = true;
+        }     
+    }
+}
+```

--- a/blazor/file-manager/drag-and-drop.md
+++ b/blazor/file-manager/drag-and-drop.md
@@ -33,7 +33,7 @@ To disable multiple file selection and enable drag-drop operations in a Blazor F
 
 After successful compilation of the application, simply press `F5` to run the application.
 
-![Drag and Drop in Blazor FileManager](images/blazor-filemanager-drag-and-drop.gif)
+![Drag and Drop in Blazor FileManager](images/blazor-filemanager-drag-and-drop.webp)
 
 ## Events
 

--- a/blazor/file-manager/how-to/adding-custom-item-to-context-menu.md
+++ b/blazor/file-manager/how-to/adding-custom-item-to-context-menu.md
@@ -62,7 +62,7 @@ The following example shows adding a custom item in the context menu. The `Conte
 
 After successful compilation of your application, simply press `F5` to run the application.
 
-![Blazor File Manager with Custom Context Menu](../images/blazor-filemanager-custom-context-menu.png)
+![Blazor File Manager with Custom Context Menu](../images/blazor-filemanager-custom-context-menu.webp)
 
 ## Handling Custom Menu Item Clicks
 

--- a/blazor/file-manager/how-to/adding-custom-item-to-context-menu.md
+++ b/blazor/file-manager/how-to/adding-custom-item-to-context-menu.md
@@ -9,33 +9,249 @@ documentation: ug
 
 # Adding Custom Item to Context Menu in Blazor File Manager Component
 
-The context menu can be customized using the [`ContextMenuSettings`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.FileManager.FileManagerContextMenuSettings.html), [`MenuOpened`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.FileManager.FileManagerEvents-1.html#Syncfusion_Blazor_FileManager_FileManagerEvents_1_MenuOpened), and [`OnMenuClick`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.FileManager.FileManagerEvents-1.html#Syncfusion_Blazor_FileManager_FileManagerEvents_1_OnMenuClick) events.
+The context menu can be customized using the [`ContextMenuSettings`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.FileManager.FileManagerContextMenuSettings.html), [`MenuOpened`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.FileManager.FileManagerEvents-1.html#Syncfusion_Blazor_FileManager_FileManagerEvents_1_MenuOpened), and [`OnMenuClick`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.FileManager.FileManagerEvents-1.html#Syncfusion_Blazor_FileManager_FileManagerEvents_1_OnMenuClick) events. Additionally, the File Manager component provides [`DisableMenuItems()`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.FileManager.SfFileManager-1.html#Syncfusion_Blazor_FileManager_SfFileManager_1_DisableMenuItems_System_String___) and [`EnableMenuItems()`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.FileManager.SfFileManager-1.html#Syncfusion_Blazor_FileManager_SfFileManager_1_EnableMenuItems_System_String___) methods for dynamic menu item management based on application logic and user permissions. For detailed information about context menu properties, refer to the [Context Menu documentation](../context-menu.md).
 
-The following example shows adding a custom item in the context menu. The `ContextMenuSettings` is used to add new menu item. The `MenuOpened` event is used to add the icon to the new menu item. The `OnMenuClick` event is used to add an event handler to the new menu item.
+## Adding Custom Menu Items
+
+The following example shows adding a custom item in the context menu. The `ContextMenuSettings` is used to add new menu item. The [`MenuOpened`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.FileManager.FileManagerEvents-1.html#Syncfusion_Blazor_FileManager_FileManagerEvents_1_MenuOpened) event is used to add the icon to the new menu item. The [`OnMenuClick`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.FileManager.FileManagerEvents-1.html#Syncfusion_Blazor_FileManager_FileManagerEvents_1_OnMenuClick) event is used to add an event handler to the new menu item.
 
 ```cshtml
 
 @using Syncfusion.Blazor.FileManager
 
-    <SfFileManager TValue="FileManagerDirectoryContent">
-        <FileManagerAjaxSettings Url="/api/SampleData/FileOperations"
-                                 UploadUrl="/api/SampleData/Upload"
-                                 DownloadUrl="/api/SampleData/Download"
-                                 GetImageUrl="/api/SampleData/GetImage">
-        </FileManagerAjaxSettings>
-        <FileManagerContextMenuSettings  File="@Items" Folder="@Items"></FileManagerContextMenuSettings>
-    </SfFileManager>
+<SfFileManager TValue="FileManagerDirectoryContent" @ref="FileManager">
+    <FileManagerEvents TValue="FileManagerDirectoryContent"></FileManagerEvents>
+    <FileManagerAjaxSettings Url="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/FileOperations"
+                             UploadUrl="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/Upload"
+                             DownloadUrl="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/Download"
+                             GetImageUrl="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/GetImage">
+    </FileManagerAjaxSettings>
+    <FileManagerContextMenuSettings File="@Items" Folder="@Items" Layout="@Items"></FileManagerContextMenuSettings>
+    <FileManagerEvents TValue="FileManagerDirectoryContent" MenuOpened="MenuOpened" OnMenuClick="OnMenuClick"></FileManagerEvents>
+</SfFileManager>
 
 @code {
-    public string[] Items = new string[] { "Open", "|", "Delete", "Download", "Rename", "|", "Details", "Custom" };
+    SfFileManager<FileManagerDirectoryContent>? FileManager;
+    // Define custom menu items by adding "Custom" to the items array
+    public string[] Items = new string[] { "NewFolder", "Upload", "Delete", "Download", "Rename", "SortBy", "Refresh", "Selection", "View", "Details", "Custom" };
+    public void MenuOpened(MenuOpenEventArgs<FileManagerDirectoryContent> args)
+    {
+        // Customize the appearance of the custom menu item when the context menu opens
+        for(int i=0; i < args.Items.Count(); i++)
+        {
+            if (args.Items[i].Id == FileManager?.ID + "_cm_custom")
+            {
+                args.Items[i].IconCss = "e-icons e-fe-tick";
+            }
+        }
+    }
+    public void OnMenuClick(MenuClickEventArgs<FileManagerDirectoryContent> args)
+    {
+        // Handle custom menu item clicks here
+    }
 }
 
-```
+<style>
+    .e-fe-tick::before {
+        content: '\e614';
+    }
+</style> 
 
+```
 ## Run the application
 
 After successful compilation of your application, simply press `F5` to run the application.
 
+![Blazor File Manager with Custom Context Menu](../images/blazor-filemanager-custom-context-menu.png)
 
+## Handling Custom Menu Item Clicks
 
-![Blazor File Manager with Custom Context Menu](../images/blazor-filemanager-custom-context-menu.webp)
+The [`OnMenuClick`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.FileManager.FileManagerEvents-1.html#Syncfusion_Blazor_FileManager_FileManagerEvents_1_OnMenuClick) event fires when a user selects a context menu item. This event receives the `MenuClickEventArgs` object, which provides access to the clicked menu item through the `Item` property and file/folder details through the `FileDetails` property. This allows developers to implement custom business logic based on the clicked menu item and the context in which it was clicked.
+
+The following example shows how to handle context menu item clicks and execute custom actions such as selecting all files:
+
+```cshtml
+@using Syncfusion.Blazor.FileManager
+
+<SfFileManager TValue="FileManagerDirectoryContent" @ref="fileManager">
+    <FileManagerAjaxSettings Url="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/FileOperations"
+                             UploadUrl="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/Upload"
+                             DownloadUrl="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/Download"
+                             GetImageUrl="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/GetImage">
+    </FileManagerAjaxSettings>
+    <FileManagerContextMenuSettings File="@Items" Folder="@Items" Layout="@Items"></FileManagerContextMenuSettings>
+    <FileManagerEvents TValue="FileManagerDirectoryContent" OnMenuClick="OnMenuClick"></FileManagerEvents>
+</SfFileManager>
+
+@code {
+    SfFileManager<FileManagerDirectoryContent> fileManager;
+    public string[] Items = new string[] { "Open", "|", "Delete", "Download", "Rename", "|", "Details", "SelectAll" };
+
+    public async void OnMenuClick(MenuClickEventArgs<FileManagerDirectoryContent> args)
+    {
+        if (args.Item.Text == "SelectAll")
+        {
+            await fileManager.SelectAllAsync();
+        }
+    }
+}
+```
+
+## Enabling and Disabling Menu Items
+
+The File Manager component provides methods to programmatically control context menu item visibility and accessibility. These methods allow dynamic management of menu item states based on application logic, user permissions, or file characteristics.
+
+### DisableMenuItems Method
+
+The [`DisableMenuItems()`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.FileManager.SfFileManager-1.html#Syncfusion_Blazor_FileManager_SfFileManager_1_DisableMenuItems_System_String___) method disables specified context menu items in the File Manager component, making them non-interactive (grayed out). This is useful when certain operations should not be available based on the current context, user permissions, or application state.
+
+The following example demonstrates how to disable specific menu items. In this case, the `DisableMenuItems()` method is called within the `MenuOpened` event to restrict Delete and Rename operations:
+
+```cshtml
+@using Syncfusion.Blazor.FileManager
+
+<SfFileManager TValue="FileManagerDirectoryContent" @ref="FileManager">
+    <FileManagerAjaxSettings Url="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/FileOperations"
+                             UploadUrl="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/Upload"
+                             DownloadUrl="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/Download"
+                             GetImageUrl="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/GetImage">
+    </FileManagerAjaxSettings>
+    <FileManagerContextMenuSettings File="@Items" Folder="@Items"></FileManagerContextMenuSettings>
+    <FileManagerEvents TValue="FileManagerDirectoryContent" MenuOpened="OnMenuOpened"></FileManagerEvents>
+</SfFileManager>
+
+@code {
+    SfFileManager<FileManagerDirectoryContent> FileManager;
+    public string[] Items = new string[] { "Open", "|", "Delete", "Download", "Rename", "|", "Custom" };
+
+    public void OnMenuOpened(MenuOpenEventArgs<FileManagerDirectoryContent> args)
+    {
+        FileManager.DisableMenuItems(new string[] { "Delete", "Rename" });  
+    }
+}
+```
+
+### EnableMenuItems Method
+
+The [`EnableMenuItems()`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.FileManager.SfFileManager-1.html#Syncfusion_Blazor_FileManager_SfFileManager_1_EnableMenuItems_System_String___) method enables specified context menu items in the File Manager component, making them interactive (active). This method is used to restore menu item functionality after previously disabling them or to conditionally show items based on state changes.
+
+The following example demonstrates a common pattern: disabling menu items via a button click, then automatically re-enabling them when the context menu is opened again:
+
+```cshtml
+@using Syncfusion.Blazor.FileManager
+
+<button @onclick="DisableMenuItems" class="e-btn">Disable Menu Items</button>
+
+<SfFileManager TValue="FileManagerDirectoryContent" @ref="FileManager">
+    <FileManagerAjaxSettings Url="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/FileOperations"
+                             UploadUrl="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/Upload"
+                             DownloadUrl="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/Download"
+                             GetImageUrl="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/GetImage">
+    </FileManagerAjaxSettings>
+    <FileManagerContextMenuSettings File="@Items" Folder="@Items"></FileManagerContextMenuSettings>
+    <FileManagerEvents TValue="FileManagerDirectoryContent" MenuOpened="OnMenuOpened"></FileManagerEvents>
+</SfFileManager>
+
+@code {
+    SfFileManager<FileManagerDirectoryContent> FileManager;
+    public string[] Items = new string[] { "Open", "|", "Delete", "Download", "Rename", "|", "Details" };
+
+    public void DisableMenuItems()
+    {
+        // Disable Delete, Rename, and Download menu items when button is clicked
+        FileManager.DisableMenuItems(new string[] { "Delete", "Rename", "Download" });
+    }
+
+    public void OnMenuOpened(MenuOpenEventArgs<FileManagerDirectoryContent> args)
+    {
+        // Re-enable menu items when context menu opens
+        FileManager.EnableMenuItems(new string[] { "Delete", "Rename", "Download" });
+    }
+}
+```
+
+## Conditional Menu Item Management
+
+Menu items can be dynamically controlled based on file properties, allowing different menu options for files versus folders. The following example demonstrates enabling or disabling menu items conditionally based on whether the selected item is a file or folder:
+
+```cshtml
+@using Syncfusion.Blazor.FileManager
+
+<SfFileManager TValue="FileManagerDirectoryContent" @ref="FileManager">
+    <FileManagerAjaxSettings Url="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/FileOperations"
+                             UploadUrl="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/Upload"
+                             DownloadUrl="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/Download"
+                             GetImageUrl="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/GetImage">
+    </FileManagerAjaxSettings>
+    <FileManagerContextMenuSettings File="@FileItems" Folder="@FolderItems"></FileManagerContextMenuSettings>
+    <FileManagerEvents TValue="FileManagerDirectoryContent" MenuOpened="OnMenuOpened"></FileManagerEvents>
+</SfFileManager>
+
+@code {
+    SfFileManager<FileManagerDirectoryContent> FileManager;
+    public string[] FileItems = new string[] { "Delete", "Download", "Rename", "|", "Details", "Compress", "Archive" };
+    public string[] FolderItems = new string[] { "Open", "|", "Delete", "Rename", "|", "Details", "Archive", "Compress" };
+
+    public void OnMenuOpened(MenuOpenEventArgs<FileManagerDirectoryContent> args)
+    {
+        if (args.MenuType == "File")
+        {
+            // For files: disable archive, enable compress
+            FileManager.DisableMenuItems(new string[] { "Archive" });
+            FileManager.EnableMenuItems(new string[] { "Compress" });
+        }
+        else if (args.MenuType == "Folder")
+        {
+            // For folders: disable compress, enable archive
+            FileManager.DisableMenuItems(new string[] { "Compress" });
+            FileManager.EnableMenuItems(new string[] { "Archive" });
+        }
+    }
+}
+```
+
+### GetMenuItemIndex Method
+
+The [`GetMenuItemIndex()`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.FileManager.SfFileManager-1.html#Syncfusion_Blazor_FileManager_SfFileManager_1_GetMenuItemIndex_System_String_) method returns the index position of a specified context menu item in the File Manager component. This method is useful for programmatically identifying the position of menu items, which can be used for advanced menu manipulation, insertion of items at specific positions, or for dynamically managing menu item order based on application requirements.
+
+The method returns the zero-based index position of the specified menu item, or `-1` if the item is not found in the context menu.
+
+The following example demonstrates retrieving the index position of menu items. The `GetMenuItemIndex()` method is used to determine where specific menu items are located, which helps in programmatic menu management.
+
+```cshtml
+@using Syncfusion.Blazor.FileManager
+
+<div>@IndexMessage</div>
+
+<SfFileManager TValue="FileManagerDirectoryContent" @ref="FileManager">
+    <FileManagerAjaxSettings Url="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/FileOperations"
+                             UploadUrl="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/Upload"
+                             DownloadUrl="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/Download"
+                             GetImageUrl="https://ej2-aspcore-service.azurewebsites.net/api/FileManager/GetImage">
+    </FileManagerAjaxSettings>
+    <FileManagerContextMenuSettings File="@Items" Folder="@Items"></FileManagerContextMenuSettings>
+    <FileManagerEvents TValue="FileManagerDirectoryContent" MenuOpened="OnMenuOpened"></FileManagerEvents>
+
+</SfFileManager>
+
+@code {
+    SfFileManager<FileManagerDirectoryContent> FileManager;
+    public string IndexMessage = "";
+    public string[] Items = new string[] { "Open", "|", "Delete", "Download", "Rename", "|", "Details" };
+
+    public void OnMenuOpened(MenuOpenEventArgs<FileManagerDirectoryContent> args)
+    {
+        // Get the index position of the Delete menu item
+        int deleteIndex = FileManager.GetMenuItemIndex("Delete");
+
+        if (deleteIndex != -1)
+        {
+            IndexMessage = $"Delete menu item is at index position: {deleteIndex}";
+        }
+        else
+        {
+            IndexMessage = "Delete menu item not found";
+        }
+    }
+}
+```


### PR DESCRIPTION


## Description
Task : https://dev.azure.com/EssentialStudio/Ej2-Web/_workitems/edit/1028071/

Identified a low word count issue in the following Blazor File Manager documentation pages. The current content does not meet the expected documentation standards in terms of depth and explanation.

https://blazor.syncfusion.com/documentation/file-manager/drag-and-drop

https://blazor.syncfusion.com/documentation/file-manager/how-to/adding-custom-item-to-context-menu

## Code Studio usage(Mandatory)
- Code Studio used in this PR/MR?
    - [ ] Yes
    - [X] No
- If `Yes`: Primary use (choose one)
    - [ ] Generate new content
    - [ ] Refactor/improve existing content
    - [ ] Review assistance (explanations/summaries)
    - [ ] Other:

- Outcome
    - [ ] Saved time
    - [ ] Neutral
    - [ ] Cost time
- If “Cost time” explain in short (1 or 2 lines):

## Type of Change
- [ ] New documentation page
- [X] Update to existing documentation
- [ ] Bug fix (broken links, typos, formatting issues)
- [ ] Structural change (folders, navigation, index)
- [ ] Content improvement (clarity, examples, screenshots)
- [ ] Other (please describe):

## Reviewer Checklist (Mandatory)
- [ ] Reviewed the provided Code Studio usages related information
- [ ] Content changes follow UG/Documentation guidelines
- [ ] All provided information reviewed and verified
- [ ] Links and previews checked

