### PR TITLE
SEO-1037992-Blazor Schedular Eval Plan UG Interlinking

### DIFF
--- a/blazor/scheduler/getting-started.md
+++ b/blazor/scheduler/getting-started.md
@@ -379,6 +379,9 @@ You can configure only the required views as needed, and include additional view
 {% endhighlight %}
 {% endtabs %}
 
+N> Looking for the full Blazor Scheduler component overview, features, pricing, and documentation? Visit the 
+The [Blazor Scheduler](https://www.syncfusion.com/blazor-components/blazor-scheduler) page.
+
 ## See also
 
 1. [Getting Started with Blazor for client-side in .NET Core CLI](https://blazor.syncfusion.com/documentation/getting-started/blazor-webassembly-app)

--- a/blazor/scheduler/graphql-adptor.md
+++ b/blazor/scheduler/graphql-adptor.md
@@ -1034,4 +1034,4 @@ This guide demonstrates how to:
 3. Running the Application. [🔗](#running-the-application)
 4. Complete Sample Repository. [🔗](#complete-sample-repository)
 
-The application now provides a complete solution for managing Appointments with a modern [Blazor Scheduler](https://www.syncfusion.com/blazor-components/blazor-scheduler) integrated with a Hot Chocolate GraphQL backend.
+The application now provides a complete solution for managing Appointments with a modern Blazor Scheduler integrated with a Hot Chocolate GraphQL backend.

--- a/blazor/scheduler/how-to/blazor-web-assembly-scheduler.md
+++ b/blazor/scheduler/how-to/blazor-web-assembly-scheduler.md
@@ -9,7 +9,7 @@ documentation: ug
 
 # Blazor Scheduler Component in WebAssembly App using Visual Studio
 
-This article provides a step-by-step instructions for building Blazor WebAssembly App with Blazor Scheduler component using [Visual Studio](https://visualstudio.microsoft.com/vs/).
+This article provides a step-by-step instructions for building Blazor WebAssembly App with [Blazor Scheduler](https://www.syncfusion.com/blazor-components/blazor-scheduler) component using [Visual Studio](https://visualstudio.microsoft.com/vs/).
 
 ## Prerequisites
 
@@ -17,9 +17,9 @@ This article provides a step-by-step instructions for building Blazor WebAssembl
 
 ## Create a Blazor WebAssembly App in Visual Studio
 
-You can create a **Blazor WebAssembly App** using Visual Studio via [Microsoft Templates](https://learn.microsoft.com/en-us/aspnet/core/blazor/tooling?view=aspnetcore-7.0&pivots=vs) or the [Syncfusion® Blazor Extension](https://blazor.syncfusion.com/documentation/visual-studio-integration/template-studio).
+You can create a **Blazor WebAssembly App** using Visual Studio via [Microsoft Templates](https://learn.microsoft.com/en-us/aspnet/core/blazor/tooling?view=aspnetcore-7.0&pivots=vs) or the [Blazor Scheduler Extension](https://blazor.syncfusion.com/documentation/visual-studio-integration/template-studio).
 
-## Install required NuGet packages in the App
+## Install Blazor Scheduler and Themes NuGet in the App
 
 To add `Blazor Scheduler` component in the app, open the NuGet package manager in Visual Studio (*Tools → NuGet Package Manager → Manage NuGet Packages for Solution*), search and install [Syncfusion.Blazor.Schedule](https://www.nuget.org/packages/Syncfusion.Blazor.Schedule) and [Syncfusion.Blazor.Themes](https://www.nuget.org/packages/Syncfusion.Blazor.Themes/). Alternatively, you can utilize the following package manager command to achieve the same.
 
@@ -33,9 +33,9 @@ Install-Package Syncfusion.Blazor.Themes -Version {{ site.releaseversion }}
 {% endhighlight %}
 {% endtabs %}
 
-N> Blazor components are available in [nuget.org](https://www.nuget.org/packages?q=syncfusion.blazor). Refer to [NuGet packages](https://blazor.syncfusion.com/documentation/nuget-packages) topic for available NuGet packages list with component details.
+N> Blazor Scheduler components are available in [nuget.org](https://www.nuget.org/packages?q=syncfusion.blazor). Refer to [NuGet packages](https://blazor.syncfusion.com/documentation/nuget-packages) topic for available NuGet packages list with component details.
 
-## Register Blazor Service
+## Register Blazor Scheduler Service
 
 Open **~/_Imports.razor** file and import the `Syncfusion.Blazor` and `Syncfusion.Blazor.Schedule` namespace.
 
@@ -48,7 +48,7 @@ Open **~/_Imports.razor** file and import the `Syncfusion.Blazor` and `Syncfusio
 {% endhighlight %}
 {% endtabs %}
 
-Now, register the Blazor Service in the **~/Program.cs** file of your Blazor WebAssembly App.
+Now, register the Blazor Scheduler Service in the **~/Program.cs** file of your Blazor WebAssembly App.
 
 {% tabs %}
 {% highlight C# tabtitle="Blazor WebAssembly App" hl_lines="3 11" %}

--- a/blazor/scheduler/how-to/create-multiple-events-dynamically.md
+++ b/blazor/scheduler/how-to/create-multiple-events-dynamically.md
@@ -9,7 +9,7 @@ documentation: ug
 
 # Add Multi Events in different slots in Blazor Scheduler Component
 
-In Blazor Scheduler, we can select the different time slots (10:00 - 10:30, 8:00 - 8:30) by holding CTRL key and click on cells using `OnCellClick` event. In the following code example, events are created on selected timeslots when clicking the **Add Appointments** button.
+In [Blazor Scheduler](https://www.syncfusion.com/blazor-components/blazor-scheduler), we can select the different time slots (10:00 - 10:30, 8:00 - 8:30) by holding CTRL key and click on cells using `OnCellClick` event. In the following code example, events are created on selected timeslots when clicking the **Add Appointments** button.
 
 ```cshtml
 @using Syncfusion.Blazor

--- a/blazor/scheduler/webassembly-performance.md
+++ b/blazor/scheduler/webassembly-performance.md
@@ -9,7 +9,7 @@ documentation: ug
 
 # WebAssembly Performance in Blazor Scheduler Component
 
-This section provides performance guidelines for using [Blazor Scheduler](https://www.syncfusion.com/blazor-components/blazor-scheduler) component efficiently in Blazor WebAssembly application. The best practice or guidelines for general framework Blazor WebAssembly performance can be found [here](https://learn.microsoft.com/en-us/aspnet/core/blazor/performance?view=aspnetcore-7.0).
+This section provides performance guidelines for using Blazor Scheduler component efficiently in Blazor WebAssembly application. The best practice or guidelines for general framework Blazor WebAssembly performance can be found [here](https://learn.microsoft.com/en-us/aspnet/core/blazor/performance?view=aspnetcore-7.0).
 
 N> You can refer to our Getting Started with [Blazor Server-Side Scheduler](https://blazor.syncfusion.com/documentation/getting-started/blazor-server-side-visual-studio) and [Blazor WebAssembly Scheduler](./how-to/blazor-web-assembly-scheduler) documentation pages for configuration specifications.
 


### PR DESCRIPTION
Hi @GowriLoganathan,

Please review

I have worked on the Blazor Schedular - UG for the following requests from the Eval team

Modifying interlinking text
Change all interlinking of Syncfusion Blazor Schedular to Blazor Schedular in all the documentation pages
Adding NOTES section in getting started page

Regards,
Asha