### PR TITLE
Documentation(857424): Fixed the ShimmerEffect enum values API reference and None effect documentation issue in the Blazor Skeleton UG

### DIFF
--- a/blazor/skeleton/effects.md
+++ b/blazor/skeleton/effects.md
@@ -9,7 +9,7 @@ documentation: ug
 
 # Shimmer Effect in Blazor Skeleton Component
 
-You can use the [Effect](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.Notifications.SfSkeleton.html#Syncfusion_Blazor_Notifications_SfSkeleton_Effect) property to change animation effect in the skeleton component. Skeleton supports `Wave`, `Pulse` and `Fade` effects and by default, the `Effect` is set to `Wave` effect.
+You can use the [`Effect`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.Notifications.SfSkeleton.html#Syncfusion_Blazor_Notifications_SfSkeleton_Effect) property to change animation effect in the skeleton component. Skeleton supports [`Wave`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.Notifications.ShimmerEffect.html#Syncfusion_Blazor_Notifications_ShimmerEffect_Wave), [`Pulse`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.Notifications.ShimmerEffect.html#Syncfusion_Blazor_Notifications_ShimmerEffect_Pulse), [`Fade`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.Notifications.ShimmerEffect.html#Syncfusion_Blazor_Notifications_ShimmerEffect_Fade), and [`None`](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.Notifications.ShimmerEffect.html#Syncfusion_Blazor_Notifications_ShimmerEffect_None) effects and by default, the `Effect` is set to `Wave` effect. If no animation effect is required, set the `Effect` property to `None`.
 
 {% tabs %}
 {% highlight razor %}


### PR DESCRIPTION
## Description

Documentation([857424](https://support.bolddesk.com/agent/tickets/857424)): Fixed the issue in the Blazor Skeleton Effects UG documentation by adding API reference links for the ShimmerEffect enum values and documenting the None effect option when no shimmer animation is required.

## Code Studio usage(Mandatory)
- Code Studio used in this PR/MR?
    - [ ] Yes
    - [x] No
- If `Yes`: Primary use (choose one)
    - [ ] Generate new content
    - [ ] Refactor/improve existing content
    - [ ] Review assistance (explanations/summaries)
    - [ ] Other:

- Outcome
    - [ ] Saved time
    - [ ] Neutral
    - [ ] Cost time
- If “Cost time” explain in short (1 or 2 lines):

## Type of Change
- [ ] New documentation page
- [ ] Update to existing documentation
- [x] Bug fix (broken links, typos, formatting issues)
- [ ] Structural change (folders, navigation, index)
- [ ] Content improvement (clarity, examples, screenshots)
- [ ] Other (please describe):

## Reviewer Checklist (Mandatory)
- [ ] Reviewed the provided Code Studio usages related information
- [ ] Content changes follow UG/Documentation guidelines
- [ ] All provided information reviewed and verified
- [ ] Links and previews checked