### PR TITLE
Documentation(856820): Fixed the Sidebar .NET 8 documentation sample issue in the Blazor Sidebar UG

### DIFF
--- a/blazor/sidebar/how-to/sidebar-in-the-dotnet8-application.md
+++ b/blazor/sidebar/how-to/sidebar-in-the-dotnet8-application.md
@@ -13,7 +13,7 @@ documentation: ug
 
 Integrate the Blazor Sidebar component into the `MainLayout.razor` page of the .NET 8 application. Next, include the `@rendermode InteractiveServer` directive in the `Routes.razor` page of the application. When you specify InteractiveServer as the render mode for the Routes component, you are enabling interactive server-side rendering (SSR) for your entire Blazor application.
 
-N> Add the following code in the `MainLayout.razor` file. The `@Body` property is available only in layout components. If the code is copied into a page such as `Index.razor` or `Home.razor`, the application will throw the compiler error: `CS0103: The name 'Body' does not exist in the current context`.
+N> Add the following code in the `MainLayout.razor` file. The `@Body` property is available only in layout components.
 
 {% tabs %}
 {% highlight razor tabtitle="MainLayout.razor" %}

--- a/blazor/sidebar/how-to/sidebar-in-the-dotnet8-application.md
+++ b/blazor/sidebar/how-to/sidebar-in-the-dotnet8-application.md
@@ -13,7 +13,10 @@ documentation: ug
 
 Integrate the Blazor Sidebar component into the `MainLayout.razor` page of the .NET 8 application. Next, include the `@rendermode InteractiveServer` directive in the `Routes.razor` page of the application. When you specify InteractiveServer as the render mode for the Routes component, you are enabling interactive server-side rendering (SSR) for your entire Blazor application.
 
-```cshtml
+N> Add the following code in the `MainLayout.razor` file. The `@Body` property is available only in layout components. If the code is copied into a page such as `Index.razor` or `Home.razor`, the application will throw the compiler error: `CS0103: The name 'Body' does not exist in the current context`.
+
+{% tabs %}
+{% highlight razor tabtitle="MainLayout.razor" %}
 
 @using Syncfusion.Blazor.Navigations
 @using Syncfusion.Blazor.Inputs
@@ -167,14 +170,15 @@ Integrate the Blazor Sidebar component into the `MainLayout.razor` page of the .
 
 </style>
 
-```
+{% endhighlight %}
+{% endtabs %}
 
-```cshtml
-
-<--Add it in Router.razor--->
+{% tabs %}
+{% highlight razor tabtitle="Routes.razor" %}
 
 @rendermode InteractiveServer
 
 <!-- Other codes -->
 
-```
+{% endhighlight %}
+{% endtabs %}


### PR DESCRIPTION
## Description

Documentation([856820](https://support.bolddesk.com/agent/tickets/856820)): Fixed the Sidebar .NET 8 UG documentation issue by clearly identifying the `MainLayout.razor` and `Routes.razor` code samples and adding a note to indicate that the sample should be added in the layout component to avoid compilation issues.

## Code Studio usage(Mandatory)
- Code Studio used in this PR/MR?
    - [ ] Yes
    - [x] No
- If `Yes`: Primary use (choose one)
    - [ ] Generate new content
    - [ ] Refactor/improve existing content
    - [ ] Review assistance (explanations/summaries)
    - [ ] Other:

- Outcome
    - [ ] Saved time
    - [ ] Neutral
    - [ ] Cost time
- If “Cost time” explain in short (1 or 2 lines):

## Type of Change
- [ ] New documentation page
- [ ] Update to existing documentation
- [x] Bug fix (broken links, typos, formatting issues)
- [ ] Structural change (folders, navigation, index)
- [ ] Content improvement (clarity, examples, screenshots)
- [ ] Other (please describe):

## Reviewer Checklist (Mandatory)
- [ ] Reviewed the provided Code Studio usages related information
- [ ] Content changes follow UG/Documentation guidelines
- [ ] All provided information reviewed and verified
- [ ] Links and previews checked