### PR TITLE
Documentation(856676): Resolved documentation issues in the Blazor ListBox Icons and Templates UG

### DIFF
--- a/blazor/listbox/icons-and-templates.md
+++ b/blazor/listbox/icons-and-templates.md
@@ -11,7 +11,9 @@ documentation: ug
 
 ## Icons
 
-To display an icon for each ListBox item, map the [IconCss field](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DropDowns.ListBoxFieldSettings.html#Syncfusion_Blazor_DropDowns_ListBoxFieldSettings_IconCss) to a CSS class name. By default, the icon is positioned on the left side of the item text. Icon glyphs are provided by the theme CSS; custom icons can also be supplied via user-defined CSS classes.
+The ListBox supports two icon sources: built-in Syncfusion icon classes, such as `e-list-settings`, and custom CSS classes defined in the application. The `e-icons` class is part of the Syncfusion Blazor icons library, which provides font icons used across Syncfusion Blazor components. Refer to the [Blazor icons library](https://blazor.syncfusion.com/documentation/appearance/icons) documentation for more details about available icons and usage.
+
+To display an icon for each ListBox item, map the [IconCss field](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DropDowns.ListBoxFieldSettings.html#Syncfusion_Blazor_DropDowns_ListBoxFieldSettings_IconCss) to the data source property that contains the icon CSS classes. The `IconCss` field accepts a CSS class name, or multiple class names separated by a space, to display an icon for each item. Icon glyphs are provided by the theme CSS, and custom icons can also be supplied using application-defined CSS classes. By default, the icon is positioned on the left side of the item text.
 
 In the following example, icon classes are mapped to the `IconCss` field.
 
@@ -23,7 +25,7 @@ In the following example, icon classes are mapped to the `IconCss` field.
 </SfListBox>
 
 @code {
-     public List<SettingItems> SettingsData = new List<SettingItems> {
+    public List<SettingItems> SettingsData = new List<SettingItems> {
         new SettingItems{ Text = "Settings", IconCss = "e-icons e-list-settings" },
         new SettingItems{ Text = "Save", IconCss = "e-icons e-list-save" },
         new SettingItems{ Text = "Save As", IconCss = "e-icons e-list-saveas" },
@@ -33,8 +35,8 @@ In the following example, icon classes are mapped to the `IconCss` field.
     };
 
     public class SettingItems {
-        public string Text  { get; set; }
-        public string IconCss  { get; set; }
+        public string Text { get; set; }
+        public string IconCss { get; set; }
     }
 
 }
@@ -70,32 +72,32 @@ In the following example, icon classes are mapped to the `IconCss` field.
 
 ## Templates
 
-ListBox items can be customized according to the requirement using [ItemTemplate](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DropDowns.SfListBox-2.html) property.
+The [ListBoxTemplates](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DropDowns.ListBoxTemplates-1.html) component provides template customization options for ListBox items. The [ItemTemplate](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DropDowns.ListBoxTemplates-1.html#Syncfusion_Blazor_DropDowns_ListBoxTemplates_1_ItemTemplate) property customizes how each list item is rendered in the ListBox. It can be used to display rich content such as avatars, badges, descriptions, or any custom markup for each item.
 
 ```cshtml
 @using Syncfusion.Blazor.DropDowns
 
 <SfListBox TValue="string[]" DataSource="@Data" TItem="ListData">
-<ListBoxFieldSettings Text="Text"></ListBoxFieldSettings>
+    <ListBoxFieldSettings Text="Text"></ListBoxFieldSettings>
     <ListBoxTemplates TItem="ListData">
         <ItemTemplate>
             <div class="list-wrapper">
                 <span class="@((context as ListData).Pic) e-avatar e-avatar-xlarge e-avatar-circle"></span>
-                <span class="text">@((context as ListData).Text)</span><span class="description">@((context as ListData).Description)</span>
+                <span class="text">@((context as ListData).Text)</span>
+                <span class="description">@((context as ListData).Description)</span>
             </div>
         </ItemTemplate>
     </ListBoxTemplates>
 </SfListBox>
 
 @code {
-    public ListData Model = new ListData();
     public List<ListData> Data = new List<ListData>
     {
         new ListData { Text = "Javascript", Pic = "javascript", Description = "It is a lightweight interpreted or JIT-compiled programming language." },
         new ListData { Text = "Typescript", Pic = "typescript", Description = "It is a typed superset of Javascript that compiles to plain JavaScript." },
         new ListData { Text = "Angular", Pic = "angular", Description = "It is a TypeScript-based open-source web application framework." },
         new ListData { Text = "React", Pic = "react", Description = "A JavaScript library for building user interfaces. It can also render on the server using Node." },
-        new ListData { Text = "Vue", Pic = "vue", Description = "A progressive framework for building user interfaces. it is incrementally adoptable." }
+        new ListData { Text = "Vue", Pic = "vue", Description = "A progressive framework for building user interfaces. It is incrementally adoptable." }
     };
 
     public class ListData
@@ -154,7 +156,7 @@ ListBox items can be customized according to the requirement using [ItemTemplate
     }
 
     .typescript {
-        background-image: url('./images/typescript.svg')
+        background-image: url('./images/typescript.svg');
     }
 
     .angular {

--- a/blazor/listbox/icons-and-templates.md
+++ b/blazor/listbox/icons-and-templates.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Icons and Templates in Blazor ListBox Component | Syncfusion®
-description: Checkout and learn here all about icons and templates in Blazor ListBox component and more.
+description: Checkout and learn here all about how to add icons and customize templates in the Blazor ListBox component and much more details.
 platform: Blazor
 control: List Box
 documentation: ug


### PR DESCRIPTION
## Description

Documentation([856676](https://support.bolddesk.com/agent/tickets/856676)): Fixed the following issues in the Blazor ListBox Icons and Templates UG documentation:

- Removed the unused `Model` variable from the Templates sample code.
- Updated the `ItemTemplate` API reference link to point to the correct `ListBoxTemplates<TItem>.ItemTemplate` API page.
- Fixed the indentation of `ListBoxFieldSettings` under `SfListBox` in both code examples.
- Added an introduction for the `ItemTemplate` property in the Templates section.
- Added an introduction for icon customization in the Icons section.
- Added details about the Syncfusion Blazor icons library used by the `e-icons` class.
- Added the `ListBoxTemplates` API reference link in the Templates section.
- Updated the `IconCss` field description with details about built-in icon classes and custom CSS classes.

## Code Studio usage(Mandatory)
- Code Studio used in this PR/MR?
    - [ ] Yes
    - [x] No
- If `Yes`: Primary use (choose one)
    - [ ] Generate new content
    - [ ] Refactor/improve existing content
    - [ ] Review assistance (explanations/summaries)
    - [ ] Other:

- Outcome
    - [ ] Saved time
    - [ ] Neutral
    - [ ] Cost time
- If “Cost time” explain in short (1 or 2 lines):

## Type of Change
- [ ] New documentation page
- [ ] Update to existing documentation
- [x] Bug fix (broken links, typos, formatting issues)
- [ ] Structural change (folders, navigation, index)
- [ ] Content improvement (clarity, examples, screenshots)
- [ ] Other (please describe):

## Reviewer Checklist (Mandatory)
- [ ] Reviewed the provided Code Studio usages related information
- [ ] Content changes follow UG/Documentation guidelines
- [ ] All provided information reviewed and verified
- [ ] Links and previews checked