### PR TITLE
Documentation(856803): Fixed the issues in the Blazor ListBox Sorting and Grouping, and Style and Appearance UG

### DIFF
--- a/blazor/listbox/sorting-grouping.md
+++ b/blazor/listbox/sorting-grouping.md
@@ -19,7 +19,7 @@ In the following example, `SortOrder` is set to `Descending`.
 @using Syncfusion.Blazor.DropDowns
 
 <SfListBox TValue="string[]" DataSource="@CountryData" SortOrder="Syncfusion.Blazor.DropDowns.SortOrder.Descending" TItem="CountryCode">
-  <ListBoxFieldSettings Text="Name" Value="Code" />
+    <ListBoxFieldSettings Text="Name" Value="Code" />
 </SfListBox>
 
 @code {
@@ -58,7 +58,7 @@ Watch the video below for a quick introduction to grouping in the Blazor ListBox
 @using Syncfusion.Blazor.DropDowns
 
 <SfListBox TValue="string[]" DataSource="@VegetableData" TItem="VegetableDetail">
-  <ListBoxFieldSettings GroupBy = "Category" Text="Vegetable" Value="Id" />
+    <ListBoxFieldSettings GroupBy="Category" Text="Vegetable" Value="Id" />
 </SfListBox>
 
 @code {

--- a/blazor/listbox/style-and-appearance.md
+++ b/blazor/listbox/style-and-appearance.md
@@ -28,6 +28,8 @@ Use the [CssClass](https://help.syncfusion.com/cr/blazor/Syncfusion.Blazor.DropD
 {% tabs %}
 {% highlight razor %}
 
+@using Syncfusion.Blazor.DropDowns
+
 <div id="listbox-control">
     <h6>Select your favorite car:</h6>
     <SfListBox Value=@Value CssClass="e-horizontal-listbox" DataSource="@Data" TValue="string[]" TItem="DataValues"></SfListBox>


### PR DESCRIPTION
## Description

Documentation([856803](https://support.bolddesk.com/agent/tickets/856803)): Fixed the following issues in the Blazor ListBox Sorting and Grouping, and Style and Appearance UG documentation:

- Corrected the spacing in the `GroupBy` field mapping.
- Standardized the indentation of `ListBoxFieldSettings` in the sorting and grouping examples.
- Added the missing `Syncfusion.Blazor.DropDowns` namespace to the Horizontal ListBox example.

## Code Studio usage(Mandatory)
- Code Studio used in this PR/MR?
    - [ ] Yes
    - [x] No
- If `Yes`: Primary use (choose one)
    - [ ] Generate new content
    - [ ] Refactor/improve existing content
    - [ ] Review assistance (explanations/summaries)
    - [ ] Other:

- Outcome
    - [ ] Saved time
    - [ ] Neutral
    - [ ] Cost time
- If “Cost time” explain in short (1 or 2 lines):

## Type of Change
- [ ] New documentation page
- [x] Update to existing documentation
- [x] Bug fix (broken links, typos, formatting issues)
- [ ] Structural change (folders, navigation, index)
- [x] Content improvement (clarity, examples, screenshots)
- [ ] Other (please describe):

## Reviewer Checklist (Mandatory)
- [ ] Reviewed the provided Code Studio usages related information
- [ ] Content changes follow UG/Documentation guidelines
- [ ] All provided information reviewed and verified
- [ ] Links and previews checked